### PR TITLE
Fix early exit from validation before all terms are used

### DIFF
--- a/src/year2024/day07.rs
+++ b/src/year2024/day07.rs
@@ -81,10 +81,17 @@ pub fn part2(input: &Input) -> u64 {
 }
 
 fn valid(terms: &[u64], test_value: u64, index: usize, concat: bool) -> bool {
-    (test_value == 0)
-        || (concat
-            && test_value % next_power_of_ten(terms[index]) == terms[index]
-            && valid(terms, test_value / next_power_of_ten(terms[index]), index - 1, concat))
+    if test_value == 0 {
+        return index == 0;
+    }
+
+    if index == 0 {
+        return false;
+    }
+
+    (concat
+        && test_value % next_power_of_ten(terms[index]) == terms[index]
+        && valid(terms, test_value / next_power_of_ten(terms[index]), index - 1, concat))
         || (test_value % terms[index] == 0
             && valid(terms, test_value / terms[index], index - 1, concat))
         || (test_value >= terms[index]

--- a/tests/year2024/day07_test.rs
+++ b/tests/year2024/day07_test.rs
@@ -11,14 +11,23 @@ const EXAMPLE: &str = "\
 21037: 9 7 18 13
 292: 11 6 16 20";
 
+const EXAMPLE2: &str = "\
+190: 10 19
+11174: 15 8 9 79 74
+729: 6 6 7 37 650";
+
 #[test]
 fn part1_test() {
     let input = parse(EXAMPLE);
     assert_eq!(part1(&input), 3749);
+    let input2 = parse(EXAMPLE2);
+    assert_eq!(part1(&input2), 190);
 }
 
 #[test]
 fn part2_test() {
     let input = parse(EXAMPLE);
     assert_eq!(part2(&input), 11387);
+    let input2 = parse(EXAMPLE2);
+    assert_eq!(part2(&input2), 11364);
 }


### PR DESCRIPTION
I'm learning rust, came across your repository and have used it as the basis of my own to learn from.
Thankyou so much for making it public, I'm learning a lot by it.

For Day07, I managed part 1, but part 2 broke me and I looked to your repo for inspiration.

However it didn't work on my Part1 data.
I compared the lines that were different and found that on 2 of my input lines, your code has a false positive.

```none
11174: 15 8 9 79 74
729: 6 6 7 37 650
```

The valid function is returning a match before it has exhausted all terms. In both cases it finds that the target is reached before considering the first digit in the list (i.e. the final term isn't considered).

I've added a naive simple fix, you may want to make it more compact.

Again many thanks for your repo, it's been an inspiration, as I normally do this in Kotlin, but this year tried to pick up rust again (my second attempt in last few years).