### PR TITLE
Remove check in day 13

### DIFF
--- a/src/year2024/day13.rs
+++ b/src/year2024/day13.rs
@@ -56,5 +56,5 @@ fn play(&[ax, ay, bx, by, mut px, mut py]: &Claw, part_two: bool) -> i64 {
     a /= det;
     b /= det;
 
-    if part_two || (a <= 100 && b <= 100) { 3 * a + b } else { 0 }
+    3 * a + b
 }


### PR DESCRIPTION
I don't think this check is needed. (For my input at least) I still get the right answer without it.

<img width="821" alt="image" src="https://github.com/user-attachments/assets/40596978-c316-4073-85ef-73394b2c1636" />
I think the above comment about 100 presses is just to give people some bounds to allow them to try a brute force solution.