### PR TITLE
2017 primality test performance improvement

### DIFF
--- a/src/year2017/day23.rs
+++ b/src/year2017/day23.rs
@@ -51,7 +51,7 @@
 //! [`Day 18`]: crate::year2017::day18
 use crate::util::parse::*;
 
-/// We only need the vrey first number from the input.
+/// We only need the very first number from the input.
 pub fn parse(input: &str) -> u32 {
     input.unsigned()
 }
@@ -69,7 +69,10 @@ pub fn part2(input: &u32) -> usize {
 /// Simple [prime number check](https://en.wikipedia.org/wiki/Primality_test)
 /// of all factors from 2 to √n inclusive.
 fn composite(n: u32) -> Option<u32> {
-    for f in 2..=n.isqrt() {
+    if n % 2 == 0 {
+        return Some(n);
+    };
+    for f in (3..=n.isqrt()).step_by(2) {
         if n % f == 0 {
             return Some(n);
         }

--- a/src/year2017/day23.rs
+++ b/src/year2017/day23.rs
@@ -72,7 +72,7 @@ fn composite(n: u32) -> Option<u32> {
     if n % 2 == 0 {
         return Some(n);
     };
-    for f in (3..=n.isqrt()).step_by(2) {
+    for f in (3..).step_by(2).take_while(|m| m * m <= n) {
         if n % f == 0 {
             return Some(n);
         }


### PR DESCRIPTION
First of all, thank you so much for this repository. I learn a lot by working through problems and coming to your solutions when I'm stuck (which I must admit is often with AOC). This has been a gold mine for me.

While having a look at 2017 day 23 I noticed that the primality test could use some minor improvements to the performance, being only checking odd numbers (and 2), and using multiplication instead of finding the square root directly (though I'm not certain if the speed increase for that one is specific to my machine/architecture).

For me, these changes bring the benchmark results for part 2 from ~61μs down to ~25μs.