### PR TITLE
Track revisited points by segment intersection

### DIFF
--- a/src/year2016/day01.rs
+++ b/src/year2016/day01.rs
@@ -1,17 +1,45 @@
 //! # No Time for a Taxicab
 //!
-//! The solution is short as it leverages three utility classes, [`hash`] for speedy sets,
+//! The solution is short as it leverages two utility classes,
 //! [`parse`] for extracting integers from surrounding text and [`point`] for two dimensional
 //! rotations and translations.
 //!
-//! [`hash`]: crate::util::hash
+//! For part two, it is faster to remember line segments and check for intersections than
+//! to store information on every intermediate point visited.
+//!
 //! [`parse`]: crate::util::parse
 //! [`point`]: crate::util::point
-use crate::util::hash::*;
 use crate::util::parse::*;
 use crate::util::point::*;
 
 type Pair = (u8, i32);
+
+// Represent the line segment between two points.
+struct Segment {
+    x1: i32,
+    x2: i32,
+    y1: i32,
+    y2: i32,
+}
+
+fn minmax(a: i32, b: i32) -> (i32, i32) {
+    if a < b { (a, b) } else { (b, a) }
+}
+
+impl Segment {
+    fn new(first: Point, second: Point) -> Self {
+        let (x1, x2) = minmax(first.x, second.x);
+        let (y1, y2) = minmax(first.y, second.y);
+        Segment { x1, x2, y1, y2 }
+    }
+
+    // Return the point of intersection between two orthogonal segments, if there is one.
+    fn intersects(&self, other: &Segment) -> Option<Point> {
+        let overlap =
+            !(other.x2 < self.x1 || other.x1 > self.x2 || other.y2 < self.y1 || other.y1 > self.y2);
+        overlap.then_some(Point::new(self.x1.max(other.x1), self.y1.max(other.y1)))
+    }
+}
 
 pub fn parse(input: &str) -> Vec<Pair> {
     let first = input.bytes().filter(u8::is_ascii_uppercase);
@@ -35,18 +63,24 @@ pub fn part1(input: &[Pair]) -> i32 {
 pub fn part2(input: &[Pair]) -> i32 {
     let mut position = ORIGIN;
     let mut direction = UP;
-    let mut visited = FastSet::with_capacity(1000);
+    // Store two lists of segments, one for each orthogonal direction.
+    let mut this_axis = Vec::with_capacity(input.len() / 2);
+    let mut other_axis = Vec::with_capacity(input.len() / 2);
 
     for &(turn, amount) in input {
         direction =
             if turn == b'L' { direction.counter_clockwise() } else { direction.clockwise() };
+        let target = position + direction * amount;
+        // Exclude the current location from the next segment to track.
+        let segment = Segment::new(position + direction, target);
 
-        for _ in 0..amount {
-            position += direction;
-            if !visited.insert(position) {
-                return position.manhattan(ORIGIN);
+        for other in &other_axis {
+            if let Some(point) = segment.intersects(other) {
+                return point.manhattan(ORIGIN);
             }
         }
+        this_axis.push(segment);
+        (this_axis, other_axis, position) = (other_axis, this_axis, target);
     }
 
     unreachable!()


### PR DESCRIPTION
## Description

Tracking line segments and searching for intersections is faster than hashing every point along the way.  On my machine, cuts part2 runtime from 3.5us down to 0.6us.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any architecture
  specific intrinsics.
- [X] Tests pass

      cargo test

- [X] Code is formatted

      cargo fmt -- `find . -name "*.rs"`

- [X] Code is linted

      cargo clippy --all-targets --all-features

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
