### PR TITLE
Abandon setups that are unlikely to win

### DIFF
--- a/src/year2018/day24.rs
+++ b/src/year2018/day24.rs
@@ -6,6 +6,13 @@
 //! become too weak to destroy any further units. As each fight is independent, we find the
 //! minimum boost value with a multithreaded parallel search.
 //!
+//! Additionally, it is possible to speed up part 2 with a heuristic comparing the ratio of
+//! infection hit points to immune effective power, vs. the ratio of immune hit points to
+//! infection effective power. A larger ratio requires more turns to defeat the other side. It is
+//! possible to win with the larger ratio, but larger boosts bring the ratios closer together;
+//! so this code skips boosts where the immune system has more than twice the nominal work to
+//! do to wipe out the infection hit points.
+//!
 //! [`Day 15`]: crate::year2018::day15
 use crate::util::hash::*;
 use crate::util::parse::*;
@@ -21,6 +28,7 @@ enum Kind {
     Immune,
     Infection,
     Draw,
+    Unbalanced,
 }
 
 #[derive(Clone, Copy)]
@@ -117,6 +125,21 @@ fn fight(input: &Input, boost: i32) -> (Kind, i32) {
 
     // Boost reindeer's immune system.
     immune.iter_mut().for_each(|group| group.damage += boost);
+
+    // Determine if the fight is even worth running.
+    if boost != 0 {
+        let infect_hp: usize =
+            infection.iter().map(|group| (group.units * group.hit_points) as usize).sum();
+        let immune_hp: usize =
+            immune.iter().map(|group| (group.units * group.hit_points) as usize).sum();
+        let infect_eff: usize =
+            infection.iter().map(|group| (group.units * group.damage) as usize).sum();
+        let immune_eff: usize =
+            immune.iter().map(|group| (group.units * group.damage) as usize).sum();
+        if infect_hp / immune_eff > 2 * immune_hp / infect_eff {
+            return (Kind::Unbalanced, 0);
+        }
+    }
 
     for turn in 1.. {
         // Target selection phase.


### PR DESCRIPTION
## Description

2018 day 24 is somewhat input sensitive; on my machine, my input file completed in 2.5ms at a boost of 42, but another one scraped from the megathread took 5.0ms and had to reach a boost of 90.  With some tracing, I observed that the higher the boost got, the closer the ratio between baseline infect_hp/immune_eff vs. immune_hp/infect_eff. It is still possible to win even when the ratios are not equal (thanks to the group attributes tweaking actual damage), but appears that any difference larger than double is going to favor the infection - there simply won't be enough hit points to survive long enough for immune to win.

Capture this as a heuristic to bypass low-value boosts, so that the time is spent on battles more likely to matter.  For the files I tested, this cuts runtime on my machine to 2.0ms, regardless of whether the pre-patch file was 2.5ms or 5.0ms.

## Type of change

- [x] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any architecture
  specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
