### PR TITLE
Add unit test coverage for recent bug fix

### DIFF
--- a/tests/year2018/day17.rs
+++ b/tests/year2018/day17.rs
@@ -10,14 +10,28 @@ x=498, y=10..13
 x=504, y=10..13
 y=13, x=498..504";
 
+/// Some additional corner cases worth getting correct. This input produces a spread that ends
+/// adjacent to another column that already contains Moving water, as well as finding a one-column
+/// gap adjacent to unconnected clay that should still result in Moving water.
+const EXTRA: &str = "\
+x=500, y=2..3
+x=501, y=5..6
+y=7, x=501..502
+x=504, y=1..6
+y=9, x=503..504";
+
 #[test]
 fn part1_test() {
     let input = parse(EXAMPLE);
     assert_eq!(part1(&input), 57);
+    let input = parse(EXTRA);
+    assert_eq!(part1(&input), 31);
 }
 
 #[test]
 fn part2_test() {
     let input = parse(EXAMPLE);
     assert_eq!(part2(&input), 29);
+    let input = parse(EXTRA);
+    assert_eq!(part2(&input), 0);
 }


### PR DESCRIPTION
## Description

This puzzle was giving an answer that was too small for my input.  I whittled the file down to a fairly minimal testcase, by reducing my actual input file to something that still undercounted:

x=501, y=1..2
x=500, y=4..5
x=501, y=7..8
x=500, y=10..11

where the code was reporting 18 on that sample instead of 29 for part 1 (with no horizontal rows, there is no standing water so part 2 was correctly 0).  I traced it to two related problems: when a stream of water lands on a Stopped tile and starts searching for an escape path left or right, the code was advancing sideways for as long as the next tile on the row is Sand while the current tile (not the tile under the next one) is Stopped.  But when the blank space adjacent to the clay is itself adjacent to an already-present stream of water, the code never called flow() on the tile below the blank space (after the first branch at 500,3, the next branch at 501,6 checks that 500,6 is Sand and 501,7 is Stopped, moves left 1, then checks whether 499,6 is Sand and stops early because it is already Moving, without ever checking 500,6).  Then, when checking the right side, after seeing that 502,6 is Sand and 501,7 is Stopped, it tries to check 503,6 for Sand - but the dimensions of the grid meant it was actually looking at 499,7 which was already Moving.  Visually, the two problems are marked "*", and the undercounted tiles are marked ":"

```
  +
  |#
  |#
 |||
 |#|
 |#|
 *|||*
 |:#:
 |:#:
 |:::
 |#::
 |#::
```

Another problem I spotted while trying to fix it is the following setup; although it does not seem like any valid input file will actually produce this setup:

```
  +
 #|
 #~~##
 ##:
```

After seeing 500,3 is Stopped, and that 499,2 is not Sand, the code checks how far right the water should spread, and sees 501,2 is Sand and 500,3 is Stopped, but 502,2 is not Sand.  Since it never checks the state of 501,3, it ends up marking 500,2 and 500,3 as Stopped instead of Moving, with knock-on effects in row 500,1.

Fix the boundary problem by making the grid one wider: that way no existing flow of Moving water on the left of the grid can overlap with the probe to whether there is one more existing Sand to the right. Then fix the column adjacency problem by calling flow() on the two points below the left and right, in addition to their neighbors being Stopped, before declaring the row Stopped or Moving.

## Type of change

- [ ] Performance improvement
- [X] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any architecture
  specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
