### PR TITLE
Improve caching of hits

### DIFF
--- a/src/year2019/day10.rs
+++ b/src/year2019/day10.rs
@@ -71,8 +71,8 @@ pub fn parse(input: &str) -> Input {
     }
 
     // Find asteroid with the highest visibility.
-    let mut seen = Grid::new(2 * width, 2 * height, 0);
-    let mut cache = grid.same_size_with(0);
+    let mut seen = Grid::new(2 * width, height, 0);
+    let mut cache = seen.same_size_with(ORIGIN);
     let mut visible = vec![0; points.len()];
     let mut max_visible = 0;
     let mut max_index = 0;
@@ -80,19 +80,19 @@ pub fn parse(input: &str) -> Input {
     for i in 0..(points.len() - 1) {
         for j in (i + 1)..points.len() {
             let delta = points[j] - points[i];
-            let key = Point::new(delta.x.abs(), delta.y.abs());
+            // Because points was populated in order from left to right and top to bottom, delta.y will
+            // be non-negative; delta.x might be negative, but shifting it by width gives us a positive
+            // reference point that can then cache the mapping to a representative index.
+            let key = Point::new(width + delta.x, delta.y);
 
-            if cache[key] == 0 {
-                cache[key] = key.x.gcd(key.y);
+            if cache[key] == ORIGIN {
+                // Key insight is that points on the same line are integer multiples of each other.
+                let gcd = delta.x.abs().gcd(delta.y);
+                let adjusted = Point::new(delta.x / gcd + width, delta.y / gcd);
+
+                cache[key] = adjusted;
             }
-            let gcd = cache[key];
-
-            // Key insight is that points on the same line are integer multiples of each other.
-            let adjusted = Point::new(delta.x / gcd, delta.y / gcd);
-
-            // This works as the points are in order from left to right and top to bottom,
-            // so we process points from nearest to furthest.
-            let index = Point::new(width + adjusted.x, height + adjusted.y);
+            let index = cache[key];
 
             if seen[index] <= i {
                 seen[index] = i + 1;


### PR DESCRIPTION
## Description

The grid size for seen was twice as large as needed: since we pair points in reading order, delta.y will always be positive, so we don't need 2*height in the seen grid.  On the other hand, computing the gcd is only part of the effort needed to get from a particular delta back to the adjusted index that serves as the witness for the first visible asteroid along an integer-coordinate line.  Reworking the code to move more computation into the cache population, so that the cache lookup bypasses more work, provides a nice speed boost.  On my input, I count over 53 thousand point deltas, but only populate around 800 entries in the cache.  The updated cache needs double-width (the same as the seen grid), so I'm not really reducing memory usage, just using it more effectively.

On my machine, this improves runtime from around 660-790us to a faster 365-440us (the runtimes are quite variable; probably because there is enough memory in play to not comfortably fit in L1 cache).

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
