### PR TITLE
Use a faster quickselect rather than full sort

### DIFF
--- a/src/year2019/day10.rs
+++ b/src/year2019/day10.rs
@@ -130,10 +130,9 @@ pub fn parse(input: &str) -> Input {
         groups.push((first, second, i));
     }
 
-    groups.sort_unstable();
-
-    // The 200th asteroid is at index 199.
-    let target = station + points[groups[199].2];
+    // The 200th asteroid is at index 199. Quickselect is faster than a full sort.
+    let index = groups.select_nth_unstable(199).1.2;
+    let target = station + points[index];
     let result = 100 * target.x + target.y;
 
     (max_visible, result)


### PR DESCRIPTION
## Description

Followup to #66.

Sorting 350+ elements to finding the 200th in sorted order is minimum O(n log n); plus, our sort criteria was rather complex.  It is possible to simplify things by working a quadrant at a time (reusing the cache from part 1) and then use quickselect (often as fast as O(n)) on a smaller list (around 50 elements), at which point we no longer need to compute Euclidean distance as a sort tie-breaker.

Runtime improvement is minimal in relation to part 1.  On my machine, a pre-patch isolation of part2 to a separate function only took 12us, and I often had more than that much variability in the timings for parse near 400us.  And since this patch reuses cache from part 1, I can't easily separate it out for post-patch timing analysis.  But I was able to add temporary debug to angle() to prove that pre-patch called angle() 3131 times, and post-patch only 298.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
