### PR TITLE
Speed up intcode instruction decoding

### DIFF
--- a/src/util/intcode.rs
+++ b/src/util/intcode.rs
@@ -19,6 +19,14 @@ pub struct Computer {
     input: VecDeque<usize>,
 }
 
+#[derive(Clone, Copy, Default)]
+struct Decode {
+    op: u8,
+    mode1: u8,
+    mode2: u8,
+    mode3: u8,
+}
+
 impl Computer {
     pub fn new(input: &[i64]) -> Self {
         let mut code = Vec::with_capacity(input.len() + EXTRA);
@@ -46,23 +54,51 @@ impl Computer {
     /// Runs until either the program needs input, outputs a value or encounters the halt opcode.
     /// In the first two cases, the computer can be resumed by calling `run` again.
     pub fn run(&mut self) -> State {
-        loop {
-            let op = self.code[self.pc];
+        /// Preparing a decoder table at compile time avoids division operators at runtime.
+        static DECODE: [Decode; 22210] = {
+            let zero = Decode { op: 0, mode1: 0, mode2: 0, mode3: 0 };
+            let mut table = [zero; 22210];
+            let mut i = 1;
+            while i < 10 {
+                let mut j = 0;
+                while j < 3 {
+                    let mut k = 0;
+                    while k < 3 {
+                        let mut l = 0;
+                        while l < 3 {
+                            let index = i + 100 * j + 1000 * k + 10000 * l;
+                            table[index].op = i as u8;
+                            table[index].mode1 = j as u8;
+                            table[index].mode2 = k as u8;
+                            table[index].mode3 = l as u8;
+                            l += 1;
+                        }
+                        k += 1;
+                    }
+                    j += 1;
+                }
+                i += 1;
+            }
+            table
+        };
 
-            match op % 100 {
+        loop {
+            let decode = DECODE[self.code[self.pc]];
+
+            match decode.op {
                 // Add
                 1 => {
-                    let first = self.address(op / 100, 1);
-                    let second = self.address(op / 1000, 2);
-                    let third = self.address(op / 10000, 3);
+                    let first = self.address(decode.mode1, 1);
+                    let second = self.address(decode.mode2, 2);
+                    let third = self.address(decode.mode3, 3);
                     self.code[third] = self.code[first].wrapping_add(self.code[second]);
                     self.pc += 4;
                 }
                 // Multiply
                 2 => {
-                    let first = self.address(op / 100, 1);
-                    let second = self.address(op / 1000, 2);
-                    let third = self.address(op / 10000, 3);
+                    let first = self.address(decode.mode1, 1);
+                    let second = self.address(decode.mode2, 2);
+                    let third = self.address(decode.mode3, 3);
                     self.code[third] = self.code[first].wrapping_mul(self.code[second]);
                     self.pc += 4;
                 }
@@ -71,52 +107,52 @@ impl Computer {
                     let Some(value) = self.input.pop_front() else {
                         break State::Input;
                     };
-                    let first = self.address(op / 100, 1);
+                    let first = self.address(decode.mode1, 1);
                     self.code[first] = value;
                     self.pc += 2;
                 }
                 // Write output channel.
                 4 => {
-                    let first = self.address(op / 100, 1);
+                    let first = self.address(decode.mode1, 1);
                     let value = self.code[first];
                     self.pc += 2;
                     break State::Output(value as i64);
                 }
                 // Jump if true.
                 5 => {
-                    let first = self.address(op / 100, 1);
-                    let second = self.address(op / 1000, 2);
+                    let first = self.address(decode.mode1, 1);
+                    let second = self.address(decode.mode2, 2);
                     let zero = self.code[first] == 0;
                     self.pc = if zero { self.pc + 3 } else { self.code[second] };
                 }
                 // Jump if false.
                 6 => {
-                    let first = self.address(op / 100, 1);
-                    let second = self.address(op / 1000, 2);
+                    let first = self.address(decode.mode1, 1);
+                    let second = self.address(decode.mode2, 2);
                     let zero = self.code[first] == 0;
                     self.pc = if zero { self.code[second] } else { self.pc + 3 };
                 }
                 // Less than
                 7 => {
-                    let first = self.address(op / 100, 1);
-                    let second = self.address(op / 1000, 2);
-                    let third = self.address(op / 10000, 3);
+                    let first = self.address(decode.mode1, 1);
+                    let second = self.address(decode.mode2, 2);
+                    let third = self.address(decode.mode3, 3);
                     let value = (self.code[first] as i64) < (self.code[second] as i64);
                     self.code[third] = value as usize;
                     self.pc += 4;
                 }
                 // Equals
                 8 => {
-                    let first = self.address(op / 100, 1);
-                    let second = self.address(op / 1000, 2);
-                    let third = self.address(op / 10000, 3);
+                    let first = self.address(decode.mode1, 1);
+                    let second = self.address(decode.mode2, 2);
+                    let third = self.address(decode.mode3, 3);
                     let value = self.code[first] == self.code[second];
                     self.code[third] = value as usize;
                     self.pc += 4;
                 }
                 // Adjust relative base.
                 9 => {
-                    let first = self.address(op / 100, 1);
+                    let first = self.address(decode.mode1, 1);
                     self.base = self.base.wrapping_add(self.code[first]);
                     self.pc += 2;
                 }
@@ -127,9 +163,9 @@ impl Computer {
 
     /// Calculates an address using one of the three possible address modes.
     #[inline]
-    fn address(&self, mode: usize, offset: usize) -> usize {
+    fn address(&self, mode: u8, offset: usize) -> usize {
         let index = self.pc + offset;
-        match mode % 10 {
+        match mode {
             0 => self.code[index],
             1 => index,
             2 => self.base.wrapping_add(self.code[index]),

--- a/src/util/intcode.rs
+++ b/src/util/intcode.rs
@@ -19,12 +19,62 @@ pub struct Computer {
     input: VecDeque<usize>,
 }
 
-#[derive(Clone, Copy, Default)]
-struct Decode {
-    op: u8,
-    mode1: u8,
-    mode2: u8,
-    mode3: u8,
+macro_rules! generate_opcode_match {
+    // Entry point: Kick off recursion with an empty accumulator token list.
+    ($val:expr, $self:expr, [ $m1:ident, $m2:ident, $m3:ident ], [ $($ops:tt)* ]) => {
+        generate_opcode_match!(@collect $val, $self, [ $m1, $m2, $m3 ], [ $($ops)* ], [])
+    };
+
+    // 2. Recursive step: Pass the identifiers down and use simple token unrolling.
+    (@collect $val:expr, $self:expr, [ $m1:ident, $m2:ident, $m3:ident ], [ $op_id:expr => $body:expr, $($tail_ops:tt)* ], [ $($acc_arms:tt)* ]) => {
+        generate_opcode_match!(
+            @collect $val, $self, [ $m1, $m2, $m3 ], [ $($tail_ops)* ],
+            [
+                $($acc_arms)*
+
+                // Unroll directly, with $m1, $m2, $m3 provided by caller to avoid breaking any
+                // hygiene rules when using those names in $body.
+                idx if idx == 2 + (($op_id - 1) * 27) + 0 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 0, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 1 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 0, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 2 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 0, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 3 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 1, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 4 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 1, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 5 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 1, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 6 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 2, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 7 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 2, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 8 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 2, 0); $body },
+
+                idx if idx == 2 + (($op_id - 1) * 27) + 9 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 0, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 10 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 0, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 11 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 0, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 12 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 1, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 13 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 1, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 14 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 1, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 15 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 2, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 16 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 2, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 17 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 2, 1); $body },
+
+                idx if idx == 2 + (($op_id - 1) * 27) + 18 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 0, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 19 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 0, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 20 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 0, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 21 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 1, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 22 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 1, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 23 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 1, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 24 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 2, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 25 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 2, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 26 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 2, 2); $body },
+            ]
+        )
+    };
+
+    // Base case for recursion, supplying mapping for DECODE[99]=>1 for halt, and 0 for unreachable.
+    (@collect $val:expr, $self:expr, [ $m1:ident, $m2:ident, $m3:ident ], [], [ $($acc_arms:tt)* ]) => {
+        match $val {
+            1 => break State::Halted,
+            $($acc_arms)*
+            _ => unreachable!(),
+        }
+    };
 }
 
 impl Computer {
@@ -55,9 +105,9 @@ impl Computer {
     /// In the first two cases, the computer can be resumed by calling `run` again.
     pub fn run(&mut self) -> State {
         /// Preparing a decoder table at compile time avoids division operators at runtime.
-        static DECODE: [Decode; 22210] = {
-            let zero = Decode { op: 0, mode1: 0, mode2: 0, mode3: 0 };
-            let mut table = [zero; 22210];
+        /// Compact valid values down into a u8 for easier matching.
+        static DECODE: [u8; 22210] = {
+            let mut table = [0_u8; 22210];
             let mut i = 1;
             while i < 10 {
                 let mut j = 0;
@@ -67,10 +117,7 @@ impl Computer {
                         let mut l = 0;
                         while l < 3 {
                             let index = i + 100 * j + 1000 * k + 10000 * l;
-                            table[index].op = i as u8;
-                            table[index].mode1 = j as u8;
-                            table[index].mode2 = k as u8;
-                            table[index].mode3 = l as u8;
+                            table[index] = ((i - 1) * 27 + 2 + j + k * 3 + l * 9) as u8;
                             l += 1;
                         }
                         k += 1;
@@ -79,90 +126,90 @@ impl Computer {
                 }
                 i += 1;
             }
+            table[99] = 1;
             table
         };
 
         loop {
             let decode = DECODE[self.code[self.pc]];
 
-            match decode.op {
+            generate_opcode_match!(decode, self, [mode1, mode2, mode3], [
                 // Add
                 1 => {
-                    let first = self.address(decode.mode1, 1);
-                    let second = self.address(decode.mode2, 2);
-                    let third = self.address(decode.mode3, 3);
+                    let first = self.address(mode1, 1);
+                    let second = self.address(mode2, 2);
+                    let third = self.address(mode3, 3);
                     self.code[third] = self.code[first].wrapping_add(self.code[second]);
                     self.pc += 4;
-                }
+                },
                 // Multiply
                 2 => {
-                    let first = self.address(decode.mode1, 1);
-                    let second = self.address(decode.mode2, 2);
-                    let third = self.address(decode.mode3, 3);
+                    let first = self.address(mode1, 1);
+                    let second = self.address(mode2, 2);
+                    let third = self.address(mode3, 3);
                     self.code[third] = self.code[first].wrapping_mul(self.code[second]);
                     self.pc += 4;
-                }
+                },
                 // Read input channel.
                 3 => {
                     let Some(value) = self.input.pop_front() else {
                         break State::Input;
                     };
-                    let first = self.address(decode.mode1, 1);
+                    let first = self.address(mode1, 1);
                     self.code[first] = value;
                     self.pc += 2;
-                }
+                },
                 // Write output channel.
                 4 => {
-                    let first = self.address(decode.mode1, 1);
+                    let first = self.address(mode1, 1);
                     let value = self.code[first];
                     self.pc += 2;
                     break State::Output(value as i64);
-                }
+                },
                 // Jump if true.
                 5 => {
-                    let first = self.address(decode.mode1, 1);
-                    let second = self.address(decode.mode2, 2);
+                    let first = self.address(mode1, 1);
+                    let second = self.address(mode2, 2);
                     let zero = self.code[first] == 0;
                     self.pc = if zero { self.pc + 3 } else { self.code[second] };
-                }
+                },
                 // Jump if false.
                 6 => {
-                    let first = self.address(decode.mode1, 1);
-                    let second = self.address(decode.mode2, 2);
+                    let first = self.address(mode1, 1);
+                    let second = self.address(mode2, 2);
                     let zero = self.code[first] == 0;
                     self.pc = if zero { self.code[second] } else { self.pc + 3 };
-                }
+                },
                 // Less than
                 7 => {
-                    let first = self.address(decode.mode1, 1);
-                    let second = self.address(decode.mode2, 2);
-                    let third = self.address(decode.mode3, 3);
+                    let first = self.address(mode1, 1);
+                    let second = self.address(mode2, 2);
+                    let third = self.address(mode3, 3);
                     let value = (self.code[first] as i64) < (self.code[second] as i64);
                     self.code[third] = value as usize;
                     self.pc += 4;
-                }
+                },
                 // Equals
                 8 => {
-                    let first = self.address(decode.mode1, 1);
-                    let second = self.address(decode.mode2, 2);
-                    let third = self.address(decode.mode3, 3);
+                    let first = self.address(mode1, 1);
+                    let second = self.address(mode2, 2);
+                    let third = self.address(mode3, 3);
                     let value = self.code[first] == self.code[second];
                     self.code[third] = value as usize;
                     self.pc += 4;
-                }
+                },
                 // Adjust relative base.
                 9 => {
-                    let first = self.address(decode.mode1, 1);
+                    let first = self.address(mode1, 1);
                     self.base = self.base.wrapping_add(self.code[first]);
                     self.pc += 2;
-                }
-                _ => break State::Halted,
-            }
+                },
+                // Op 99 was already mapped to match arm 1 by macro.
+            ]);
         }
     }
 
     /// Calculates an address using one of the three possible address modes.
-    #[inline]
     fn address(&self, mode: u8, offset: usize) -> usize {
         let index = self.pc + offset;
         match mode {

--- a/src/year2019/intcode.rs
+++ b/src/year2019/intcode.rs
@@ -19,6 +19,14 @@ pub struct Computer {
     input: VecDeque<usize>,
 }
 
+#[derive(Clone, Copy, Default)]
+struct Decode {
+    op: u8,
+    mode1: u8,
+    mode2: u8,
+    mode3: u8,
+}
+
 impl Computer {
     pub fn new(input: &[i64]) -> Self {
         let mut code = Vec::with_capacity(input.len() + EXTRA);
@@ -46,23 +54,51 @@ impl Computer {
     /// Runs until either the program needs input, outputs a value or encounters the halt opcode.
     /// In the first two cases, the computer can be resumed by calling `run` again.
     pub fn run(&mut self) -> State {
-        loop {
-            let op = self.code[self.pc];
+        /// Preparing a decoder table at compile time avoids division operators at runtime.
+        static DECODE: [Decode; 22210] = {
+            let zero = Decode { op: 0, mode1: 0, mode2: 0, mode3: 0 };
+            let mut table = [zero; 22210];
+            let mut i = 1;
+            while i < 10 {
+                let mut j = 0;
+                while j < 3 {
+                    let mut k = 0;
+                    while k < 3 {
+                        let mut l = 0;
+                        while l < 3 {
+                            let index = i + 100 * j + 1000 * k + 10000 * l;
+                            table[index].op = i as u8;
+                            table[index].mode1 = j as u8;
+                            table[index].mode2 = k as u8;
+                            table[index].mode3 = l as u8;
+                            l += 1;
+                        }
+                        k += 1;
+                    }
+                    j += 1;
+                }
+                i += 1;
+            }
+            table
+        };
 
-            match op % 100 {
+        loop {
+            let decode = DECODE[self.code[self.pc]];
+
+            match decode.op {
                 // Add
                 1 => {
-                    let first = self.address(op / 100, 1);
-                    let second = self.address(op / 1000, 2);
-                    let third = self.address(op / 10000, 3);
+                    let first = self.address(decode.mode1, 1);
+                    let second = self.address(decode.mode2, 2);
+                    let third = self.address(decode.mode3, 3);
                     self.code[third] = self.code[first].wrapping_add(self.code[second]);
                     self.pc += 4;
                 }
                 // Multiply
                 2 => {
-                    let first = self.address(op / 100, 1);
-                    let second = self.address(op / 1000, 2);
-                    let third = self.address(op / 10000, 3);
+                    let first = self.address(decode.mode1, 1);
+                    let second = self.address(decode.mode2, 2);
+                    let third = self.address(decode.mode3, 3);
                     self.code[third] = self.code[first].wrapping_mul(self.code[second]);
                     self.pc += 4;
                 }
@@ -71,52 +107,52 @@ impl Computer {
                     let Some(value) = self.input.pop_front() else {
                         break State::Input;
                     };
-                    let first = self.address(op / 100, 1);
+                    let first = self.address(decode.mode1, 1);
                     self.code[first] = value;
                     self.pc += 2;
                 }
                 // Write output channel.
                 4 => {
-                    let first = self.address(op / 100, 1);
+                    let first = self.address(decode.mode1, 1);
                     let value = self.code[first];
                     self.pc += 2;
                     break State::Output(value as i64);
                 }
                 // Jump if true.
                 5 => {
-                    let first = self.address(op / 100, 1);
-                    let second = self.address(op / 1000, 2);
+                    let first = self.address(decode.mode1, 1);
+                    let second = self.address(decode.mode2, 2);
                     let zero = self.code[first] == 0;
                     self.pc = if zero { self.pc + 3 } else { self.code[second] };
                 }
                 // Jump if false.
                 6 => {
-                    let first = self.address(op / 100, 1);
-                    let second = self.address(op / 1000, 2);
+                    let first = self.address(decode.mode1, 1);
+                    let second = self.address(decode.mode2, 2);
                     let zero = self.code[first] == 0;
                     self.pc = if zero { self.code[second] } else { self.pc + 3 };
                 }
                 // Less than
                 7 => {
-                    let first = self.address(op / 100, 1);
-                    let second = self.address(op / 1000, 2);
-                    let third = self.address(op / 10000, 3);
+                    let first = self.address(decode.mode1, 1);
+                    let second = self.address(decode.mode2, 2);
+                    let third = self.address(decode.mode3, 3);
                     let value = (self.code[first] as i64) < (self.code[second] as i64);
                     self.code[third] = value as usize;
                     self.pc += 4;
                 }
                 // Equals
                 8 => {
-                    let first = self.address(op / 100, 1);
-                    let second = self.address(op / 1000, 2);
-                    let third = self.address(op / 10000, 3);
+                    let first = self.address(decode.mode1, 1);
+                    let second = self.address(decode.mode2, 2);
+                    let third = self.address(decode.mode3, 3);
                     let value = self.code[first] == self.code[second];
                     self.code[third] = value as usize;
                     self.pc += 4;
                 }
                 // Adjust relative base.
                 9 => {
-                    let first = self.address(op / 100, 1);
+                    let first = self.address(decode.mode1, 1);
                     self.base = self.base.wrapping_add(self.code[first]);
                     self.pc += 2;
                 }
@@ -127,9 +163,9 @@ impl Computer {
 
     /// Calculates an address using one of the three possible address modes.
     #[inline]
-    fn address(&self, mode: usize, offset: usize) -> usize {
+    fn address(&self, mode: u8, offset: usize) -> usize {
         let index = self.pc + offset;
-        match mode % 10 {
+        match mode {
             0 => self.code[index],
             1 => index,
             2 => self.base.wrapping_add(self.code[index]),

--- a/src/year2019/intcode.rs
+++ b/src/year2019/intcode.rs
@@ -19,12 +19,62 @@ pub struct Computer {
     input: VecDeque<usize>,
 }
 
-#[derive(Clone, Copy, Default)]
-struct Decode {
-    op: u8,
-    mode1: u8,
-    mode2: u8,
-    mode3: u8,
+macro_rules! generate_opcode_match {
+    // Entry point: Kick off recursion with an empty accumulator token list.
+    ($val:expr, $self:expr, [ $m1:ident, $m2:ident, $m3:ident ], [ $($ops:tt)* ]) => {
+        generate_opcode_match!(@collect $val, $self, [ $m1, $m2, $m3 ], [ $($ops)* ], [])
+    };
+
+    // 2. Recursive step: Pass the identifiers down and use simple token unrolling.
+    (@collect $val:expr, $self:expr, [ $m1:ident, $m2:ident, $m3:ident ], [ $op_id:expr => $body:expr, $($tail_ops:tt)* ], [ $($acc_arms:tt)* ]) => {
+        generate_opcode_match!(
+            @collect $val, $self, [ $m1, $m2, $m3 ], [ $($tail_ops)* ],
+            [
+                $($acc_arms)*
+
+                // Unroll directly, with $m1, $m2, $m3 provided by caller to avoid breaking any
+                // hygiene rules when using those names in $body.
+                idx if idx == 2 + (($op_id - 1) * 27) + 0 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 0, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 1 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 0, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 2 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 0, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 3 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 1, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 4 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 1, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 5 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 1, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 6 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 2, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 7 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 2, 0); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 8 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 2, 0); $body },
+
+                idx if idx == 2 + (($op_id - 1) * 27) + 9 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 0, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 10 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 0, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 11 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 0, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 12 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 1, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 13 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 1, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 14 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 1, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 15 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 2, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 16 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 2, 1); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 17 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 2, 1); $body },
+
+                idx if idx == 2 + (($op_id - 1) * 27) + 18 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 0, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 19 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 0, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 20 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 0, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 21 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 1, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 22 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 1, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 23 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 1, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 24 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (0, 2, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 25 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (1, 2, 2); $body },
+                idx if idx == 2 + (($op_id - 1) * 27) + 26 => { #[allow(unused_variables)] let ($m1, $m2, $m3) = (2, 2, 2); $body },
+            ]
+        )
+    };
+
+    // Base case for recursion, supplying mapping for DECODE[99]=>1 for halt, and 0 for unreachable.
+    (@collect $val:expr, $self:expr, [ $m1:ident, $m2:ident, $m3:ident ], [], [ $($acc_arms:tt)* ]) => {
+        match $val {
+            1 => break State::Halted,
+            $($acc_arms)*
+            _ => unreachable!(),
+        }
+    };
 }
 
 impl Computer {
@@ -55,9 +105,9 @@ impl Computer {
     /// In the first two cases, the computer can be resumed by calling `run` again.
     pub fn run(&mut self) -> State {
         /// Preparing a decoder table at compile time avoids division operators at runtime.
-        static DECODE: [Decode; 22210] = {
-            let zero = Decode { op: 0, mode1: 0, mode2: 0, mode3: 0 };
-            let mut table = [zero; 22210];
+        /// Compact valid values down into a u8 for easier matching.
+        static DECODE: [u8; 22210] = {
+            let mut table = [0_u8; 22210];
             let mut i = 1;
             while i < 10 {
                 let mut j = 0;
@@ -67,10 +117,7 @@ impl Computer {
                         let mut l = 0;
                         while l < 3 {
                             let index = i + 100 * j + 1000 * k + 10000 * l;
-                            table[index].op = i as u8;
-                            table[index].mode1 = j as u8;
-                            table[index].mode2 = k as u8;
-                            table[index].mode3 = l as u8;
+                            table[index] = ((i - 1) * 27 + 2 + j + k * 3 + l * 9) as u8;
                             l += 1;
                         }
                         k += 1;
@@ -79,90 +126,90 @@ impl Computer {
                 }
                 i += 1;
             }
+            table[99] = 1;
             table
         };
 
         loop {
             let decode = DECODE[self.code[self.pc]];
 
-            match decode.op {
+            generate_opcode_match!(decode, self, [mode1, mode2, mode3], [
                 // Add
                 1 => {
-                    let first = self.address(decode.mode1, 1);
-                    let second = self.address(decode.mode2, 2);
-                    let third = self.address(decode.mode3, 3);
+                    let first = self.address(mode1, 1);
+                    let second = self.address(mode2, 2);
+                    let third = self.address(mode3, 3);
                     self.code[third] = self.code[first].wrapping_add(self.code[second]);
                     self.pc += 4;
-                }
+                },
                 // Multiply
                 2 => {
-                    let first = self.address(decode.mode1, 1);
-                    let second = self.address(decode.mode2, 2);
-                    let third = self.address(decode.mode3, 3);
+                    let first = self.address(mode1, 1);
+                    let second = self.address(mode2, 2);
+                    let third = self.address(mode3, 3);
                     self.code[third] = self.code[first].wrapping_mul(self.code[second]);
                     self.pc += 4;
-                }
+                },
                 // Read input channel.
                 3 => {
                     let Some(value) = self.input.pop_front() else {
                         break State::Input;
                     };
-                    let first = self.address(decode.mode1, 1);
+                    let first = self.address(mode1, 1);
                     self.code[first] = value;
                     self.pc += 2;
-                }
+                },
                 // Write output channel.
                 4 => {
-                    let first = self.address(decode.mode1, 1);
+                    let first = self.address(mode1, 1);
                     let value = self.code[first];
                     self.pc += 2;
                     break State::Output(value as i64);
-                }
+                },
                 // Jump if true.
                 5 => {
-                    let first = self.address(decode.mode1, 1);
-                    let second = self.address(decode.mode2, 2);
+                    let first = self.address(mode1, 1);
+                    let second = self.address(mode2, 2);
                     let zero = self.code[first] == 0;
                     self.pc = if zero { self.pc + 3 } else { self.code[second] };
-                }
+                },
                 // Jump if false.
                 6 => {
-                    let first = self.address(decode.mode1, 1);
-                    let second = self.address(decode.mode2, 2);
+                    let first = self.address(mode1, 1);
+                    let second = self.address(mode2, 2);
                     let zero = self.code[first] == 0;
                     self.pc = if zero { self.code[second] } else { self.pc + 3 };
-                }
+                },
                 // Less than
                 7 => {
-                    let first = self.address(decode.mode1, 1);
-                    let second = self.address(decode.mode2, 2);
-                    let third = self.address(decode.mode3, 3);
+                    let first = self.address(mode1, 1);
+                    let second = self.address(mode2, 2);
+                    let third = self.address(mode3, 3);
                     let value = (self.code[first] as i64) < (self.code[second] as i64);
                     self.code[third] = value as usize;
                     self.pc += 4;
-                }
+                },
                 // Equals
                 8 => {
-                    let first = self.address(decode.mode1, 1);
-                    let second = self.address(decode.mode2, 2);
-                    let third = self.address(decode.mode3, 3);
+                    let first = self.address(mode1, 1);
+                    let second = self.address(mode2, 2);
+                    let third = self.address(mode3, 3);
                     let value = self.code[first] == self.code[second];
                     self.code[third] = value as usize;
                     self.pc += 4;
-                }
+                },
                 // Adjust relative base.
                 9 => {
-                    let first = self.address(decode.mode1, 1);
+                    let first = self.address(mode1, 1);
                     self.base = self.base.wrapping_add(self.code[first]);
                     self.pc += 2;
-                }
-                _ => break State::Halted,
-            }
+                },
+                // Op 99 was already mapped to match arm 1 by macro.
+            ]);
         }
     }
 
     /// Calculates an address using one of the three possible address modes.
-    #[inline]
     fn address(&self, mode: u8, offset: usize) -> usize {
         let index = self.pc + offset;
         match mode {


### PR DESCRIPTION
## Description

Pre-compile a map of decimal values to a 4-byte struct that is easier to utilize.  This avoids lots of runtime divisions by 10/100/1000/10000, with a noticeable speed increase.  Most obvious was day 25, which jumped from 2.5ms to 1.8ms on my machine.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
