### PR TITLE
Use a dynamic programming approach

### DIFF
--- a/src/year2019/day07.rs
+++ b/src/year2019/day07.rs
@@ -1,68 +1,127 @@
 //! # Amplification Circuit
 //!
-//! Brute force solution for both parts using the utility [`permutations`] method to test each of
-//! the possible 5! or 120 permutations of the phase settings.
+//! The biggest savings to be had here are by realizing that each machine id runs an independent
+//! linear equation on the input. For part 1, these equations are in the form Ax + B, where B can
+//! be learned by feeding in the value 0, and A can be learned by feeding in the value 1 after
+//! accounting for B. For part two, each program runs exactly 10 phases of either +1, +2, or *2 as
+//! its linear equation for the phase; all ten phases can be learned by feeding in ten copies of
+//! input 0. Running a single machine 15 times up front is a lot lighter weight than running five
+//! parallel machines per permutation being tested.
+//!
+//! Beyond that, a brute force solution using [`permutations`] requires `5!`, or 120, computations. But
+//! since all of the linear equations are increasing, we can instead take a dynamic programming
+//! approach. Given a set of machines (say ids 5, 7, and 8), we can break it into the recursive
+//! problem of determining the best score when picking one of those machines to be at one end of
+//! the chain, combined with the best score achieved by the smaller subset (select the best out of
+//! arranging 5 with the best result from 7 and 8, arranging 7 with the best result of 5 and 8, and
+//! arranging 8 with the best result from 5 and 7). This can be built up in tabular form, and
+//! results in `5 * 2⁵`, or 160, bit checks. But since half of those bits are zero, it is only
+//! `5 * 2⁴`, or 80, actual computations, beating permutations.
 //!
 //! [`permutations`]: crate::util::slice
 use super::intcode::*;
 use crate::util::parse::*;
-use crate::util::slice::*;
-use std::array::from_fn;
 
 pub fn parse(input: &str) -> Vec<i64> {
     input.iter_signed::<i64>().collect()
 }
 
 pub fn part1(input: &[i64]) -> i64 {
-    let mut result = 0;
+    // Run the computer 10 times to learn the Ax + B for each amplifier id.
+    let mut a = [0; 5];
+    let mut b = [0; 5];
     let mut computer = Computer::new(input);
 
-    let sequence = |slice: &[i64]| {
-        let mut signal = 0;
-
+    let mut output = |phase: usize, seed: i64| {
         // Send exactly 2 inputs and receive exactly 1 output per amplifier.
-        for &phase in slice {
-            computer.reset();
-            computer.input(phase);
-            computer.input(signal);
-            let State::Output(next) = computer.run() else { unreachable!() };
-            signal = next;
-        }
-
-        result = result.max(signal);
+        computer.reset();
+        computer.input(phase as i64);
+        computer.input(seed);
+        let State::Output(next) = computer.run() else { unreachable!() };
+        next
     };
 
-    [0, 1, 2, 3, 4].permutations(sequence);
-    result
+    for i in 0..5 {
+        b[i] = output(i, 0);
+        a[i] = output(i, 1) - b[i];
+    }
+
+    // Store the best score seen for each set of machines considered. Bits not set will be
+    // appended later in the chain.
+    let mut best = [0_i64; 32];
+
+    for set in 1..best.len() {
+        for amp in 0..5 {
+            // No work to do if amp is not part of the current set.
+            if set & (1 << amp) == 0 {
+                continue;
+            }
+
+            // See if adding current amp to best value from remaining subset is viable.
+            let prior = best[set ^ (1 << amp)];
+            best[set] = best[set].max(a[amp] * prior + b[amp]);
+        }
+    }
+
+    best[31]
 }
 
 pub fn part2(input: &[i64]) -> i64 {
-    let mut result = 0;
-    let mut computers: [Computer; 5] = from_fn(|_| Computer::new(input));
+    // Run the computer 5 times to learn the +1/+2/*2 for each phase of each amplifier id.
+    let mut effects = [[0; 10]; 5];
+    let mut computer = Computer::new(input);
 
-    let feedback = |slice: &[i64]| {
-        // Reset state.
-        computers.iter_mut().for_each(Computer::reset);
+    // To track the multi-phase feedback, also track the bitmask of ids per phase that perform
+    // a multiply, as well as the weight of cumulative multiplies done by all later phases.
+    let mut masks = [0; 10];
+    let mut weights = [1; 10];
 
-        // Send each initial phase setting exactly once.
-        for (computer, &phase) in computers.iter_mut().zip(slice) {
-            computer.input(phase);
-        }
-
-        // Chain amplifier inputs and outputs in a loop until all threads finish.
-        let mut signal = 0;
-
-        'outer: loop {
-            for computer in &mut computers {
-                computer.input(signal);
-                let State::Output(next) = computer.run() else { break 'outer };
-                signal = next;
+    for (id, machine) in effects.iter_mut().enumerate() {
+        // Send the id, then exactly 10 loops of 1 input and 1 output.
+        computer.reset();
+        computer.input(5 + id as i64);
+        for phase in 0..10 {
+            computer.input(0);
+            let State::Output(next) = computer.run() else { unreachable!() };
+            machine[phase] = next;
+            if next == 0 {
+                masks[phase] |= 1 << id;
+                if phase > 0 {
+                    weights[phase - 1] *= 2;
+                }
             }
         }
+    }
 
-        result = result.max(signal);
-    };
+    // Combine per-phase weights into cumulative for rest of chain.
+    for i in (0..9).rev() {
+        weights[i] *= weights[i + 1];
+    }
 
-    [5, 6, 7, 8, 9].permutations(feedback);
-    result
+    // Store the best score seen for each set of machines considered. Bits not set occur
+    // earlier in the chain.
+    let mut best = [0_i64; 32];
+
+    for set in 1..best.len() {
+        for amp in 0..5 {
+            // No work to do if amp is not part of the current set.
+            if set & (1 << amp) == 0 {
+                continue;
+            }
+
+            // Start with the best value from the subset of other machines in the set.
+            let mut val = best[set ^ (1 << amp)];
+
+            // For each phase, a +1 or +2 at this phase can determine its overall contribution
+            // to the final output based on all later multiplies (masks is used to find those in the
+            // current phase, weights for those in all later phases).
+            for phase in 0..10 {
+                let current = (masks[phase] & set).count_ones();
+                val += effects[amp][phase] * (weights[phase] << current);
+            }
+            best[set] = best[set].max(val);
+        }
+    }
+
+    best[31]
 }


### PR DESCRIPTION
## Description

Rather than run 1200 Intcode machines (5! permutations * 5 machines * 2 parts) and 240 comparisons (5! * 2 parts, O(n!) work), this problem can be solved with 15 Intcode machines (2 inputs * 5 machines for the 5 Ax+B constants in part 1, 1 input * 5 machines for the 5\*10 +1/+2/\*2 constants in part 2), followed by 160 comparisons (average 5/2 bits per set * 2^5 sets * 2 parts, O(n*2^n) work).

Massively speeds up the runtime.  On my machine, it drops from 30 and 150us for parts 1 and 2, to instead being 1.0 and 2.5us.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
