### PR TITLE
Use Held-Karp dynamic programming rather than permutations

### DIFF
--- a/src/year2015/day09.rs
+++ b/src/year2015/day09.rs
@@ -1,30 +1,55 @@
 //! # All in a Single Night
 //!
-//! This is a variant of the classic NP-hard
-//! [Travelling Salesman Problem](https://en.wikipedia.org/wiki/Travelling_salesman_problem).
+//! This is a variant of the classic NP-hard [Travelling Salesman Problem].
 //!
 //! There are 8 locations, so naively it would require checking 8! = 40,320 permutations. We can
 //! reduce this to 7!/2 = 2,520 permutations by arbitrarily choosing one of the locations as the
 //! start, and skipping lexically reversed permutations (since the path a->b->c has the same
-//! length as c->b->a).
+//! length as c->b->a). Computing the shortest and longest path is then done by completing the
+//! cycle for each permutation, then discarding the longest or shortest edge seen along the way.
+//! Skipping lexically reversed permutations is possible with
+//! [Steinhaus-Johnson-Trotter][Steinhaus-Johnson-Trotter's algorithm].
 //!
-//! We then compute the distance to complete the trip and return to the original location.
-//! Since the problem does not ask us to end up in the same location we then "break" the cycle.
-//! To compute the shortest journey we remove the longest single journey and to compute the
-//! longest journey we remove the shortest single journey.
+//! However, since the graph is complete (every node has a distance to every other node), this
+//! particular problem can be solved even faster, by avoiding the overhead of permutations and
+//! instead using [Held-Karp's dynamic programming][Held-Karp] solution. This algorithm is
+//! O(n²*2ⁿ); for our puzzle with 8 nodes, this gives `8*7/2*256/2` or 3,584 comparisons needed.
+//! On the surface, this is more comparisons than the 2,520 sequences visited by the O(n!)
+//! permutation solution, but set manipulation is less expensive than computation of permutations
+//! followed by casting out the longest or shortest edge, so it is an overall win.
+//!
+//! The core behavior of Held-Karp involves computing the function g(set, k) for all possible
+//! sets of cities, where the function represents the best (shortest or longest) distance seen so
+//! far for a given set of cities and ending on the city k which is a member of the set. Unlike the
+//! permutations approach which visits every path in the graph, Held-Karp discards information
+//! along the way to compute only the best cycle in a graph anchored to a given start point. It is
+//! easy to demonstrate a graph where the best path is not part of the best cycle (discarding the
+//! longest edge from the shortest cycle might leave you with a path longer than the graph's true
+//! shortest path, if that other path had a different start anchor). But this is easy to work
+//! around, by adding a ninth "location" with distance 0 to every other location, and using that
+//! location as the start and end for every cycle, at which point the best cycle of nine includes
+//! the best path of all eight locations.
+//!
+//! The algorithm is recursive: with a base case of g({k},k) being zero (the best distance
+//! to a singleton set from our ninth point is 0), all other g(set,k) can be computed by
+//! iterating over each member of set excluding k, and choosing the best variant g(set∖k,m)+d(k,m)
+//! possible from a smaller set ending in m. Iterating over bitmasks from 0 to 255 ensures
+//! that all earlier subsets are available when computing for a larger set.
 //!
 //! For speed we first convert each location into an index, then store the distances between
-//! every pair of locations in an array for fast lookup. Our utility [`half_permutations`] method uses
-//! [Steinhaus-Johnson-Trotter's algorithm](https://en.wikipedia.org/wiki/Steinhaus-Johnson-Trotter_algorithm) for efficiency,
-//! modifying the slice in place.
+//! every pair of locations in an array for fast lookup. Storing sets plus the last city visited
+//! requires 8 bits for the set and 3 bits for the city, for a total table size of 2¹¹ distances.
 //!
+//! [Travelling Salesman Problem]: https://en.wikipedia.org/wiki/Travelling_salesman_problem
 //! [`half_permutations`]: crate::util::slice
+//! [Steinhaus-Johnson-Trotter]: https://en.wikipedia.org/wiki/Steinhaus-Johnson-Trotter_algorithm
+//! [Held-Karp]: https://en.wikipedia.org/wiki/Held%E2%80%93Karp_algorithm
+use crate::util::bitset::*;
 use crate::util::hash::*;
 use crate::util::iter::*;
 use crate::util::parse::*;
-use crate::util::slice::*;
 
-type Result = (u32, u32);
+type Result = (u16, u16);
 
 pub fn parse(input: &str) -> Result {
     let tokens: Vec<_> = input.split_ascii_whitespace().chunk::<5>().collect();
@@ -38,7 +63,7 @@ pub fn parse(input: &str) -> Result {
     }
 
     let stride = indices.len();
-    let mut distances = vec![0; stride * stride];
+    let mut distances = vec![0_u16; stride * stride];
 
     for [start, _, end, _, distance] in &tokens {
         let start = indices[start];
@@ -49,42 +74,45 @@ pub fn parse(input: &str) -> Result {
         distances[stride * end + start] = distance;
     }
 
-    let mut global_min = u32::MAX;
-    let mut global_max = u32::MIN;
-    let mut indices: Vec<_> = (1..stride).collect();
+    // Initialize a table for each part: 2ⁿ sets with n distances per set. Default 0 matches
+    // g({k},k) of zero for all singleton sets. Initial value of other sets does not matter.
+    let mut table_one = vec![0_u16; stride * (1 << stride)];
+    let mut table_two = vec![0_u16; stride * (1 << stride)];
 
-    indices.half_permutations(|slice| {
-        let mut sum = 0;
-        let mut local_min = u32::MAX;
-        let mut local_max = u32::MIN;
-
-        let mut trip = |from, to| {
-            let distance = distances[stride * from + to];
-            sum += distance;
-            local_min = local_min.min(distance);
-            local_max = local_max.max(distance);
-        };
-
-        // First trip.
-        trip(0, slice[0]);
-        // Last trip.
-        trip(0, slice[slice.len() - 1]);
-        // Intermediate trips.
-        for i in 1..slice.len() {
-            trip(slice[i], slice[i - 1]);
+    // Visit each non-empty set in order, with no work to do for singleton sets. Start from 3,
+    // since 1 and 2 are singleton sets.
+    for set in 3_usize..(1 << stride) {
+        if set.is_power_of_two() {
+            continue;
         }
 
-        global_min = global_min.min(sum - local_max);
-        global_max = global_max.max(sum - local_min);
-    });
+        // For a given set, compute each g(set,k) for all k in the set.
+        for k in set.biterator() {
+            let subset = set ^ (1 << k);
+            let mut shortest = u16::MAX;
+            let mut longest = 0;
 
-    (global_min, global_max)
+            // For a given destination k, find which other bit m gives the best path from the
+            // subset to m, and then m to k. All table[subset] references were filled in prior
+            // iterations of the outer loop or the singleton base cases.
+            for m in subset.biterator() {
+                shortest = shortest.min(table_one[subset * stride + m] + distances[m * stride + k]);
+                longest = longest.max(table_two[subset * stride + m] + distances[m * stride + k]);
+            }
+            table_one[set * stride + k] = shortest;
+            table_two[set * stride + k] = longest;
+        }
+    }
+
+    // With the sets now built, we have stride candidates for each answer.
+    let last_row = table_one.len() - stride;
+    (*table_one[last_row..].iter().min().unwrap(), *table_two[last_row..].iter().max().unwrap())
 }
 
-pub fn part1(input: &Result) -> u32 {
+pub fn part1(input: &Result) -> u16 {
     input.0
 }
 
-pub fn part2(input: &Result) -> u32 {
+pub fn part2(input: &Result) -> u16 {
     input.1
 }

--- a/src/year2015/day13.rs
+++ b/src/year2015/day13.rs
@@ -1,24 +1,28 @@
 //! # Knights of the Dinner Table
 //!
 //! This problem is very similar to [`Day 9`] and we solve it in almost exactly the same way by
-//! computing an adjacency matrix of happiness then permuting the order of the diners.
+//! computing an adjacency matrix of happiness then running [Held-Karp] to find the longest
+//! cycle. If part one were the only problem at hand, the answer would be possible by iterating
+//! over 127 sets and then selecting among seven candidates to close the loop back to whichever
+//! abritrary point we pinned as the start.
 //!
-//! For part one we reduce the permutations from 8! = 40,320 permutations to 7!/2 = 2,520
-//! permutations by arbitrarily choosing one of the diners as the start, and skipping lexically
-//! reversed forms (seating a->b->c->a gives the same happiness as seating c->b->a->c).
-//!
-//! We solve part two at the same time by noticing that by inserting yourself between two diners
-//! you set the value of their mutual link to zero. Keeping track of the weakest link
-//! then subtracting that from the value for part one gives the result for part two at almost
-//! no additional cost.
+//! However, we are more interested in solving part two at the same time. Do this by noticing that
+//! when you insert yourself between two diners, you set the value of their mutual link to zero.
+//! This is effectively the same as inserting a ninth node into the algorithm, which we pin as the
+//! start node before iterating over 255 sets. Meanwhile, the results for part one can still be
+//! found from the table, if we also have an easy way to determine which diner was used to start
+//! the path represented by any given g(set,k). We can then manually close the loop of 8 diners
+//! by using all 8 g(255,k) plus the distance from k to the start node of that path, while the
+//! loop of 9 diners uses g(255,k) with no additional distance.
 //!
 //! [`Day 9`]: crate::year2015::day09
+//! [Held-Karp]: https://en.wikipedia.org/wiki/Held%E2%80%93Karp_algorithm
+use crate::util::bitset::*;
 use crate::util::hash::*;
 use crate::util::iter::*;
 use crate::util::parse::*;
-use crate::util::slice::*;
 
-type Input = (i32, i32);
+type Input = (i16, i16);
 
 pub fn parse(input: &str) -> Input {
     // Assign each diner an index on a first come first served basis.
@@ -34,13 +38,13 @@ pub fn parse(input: &str) -> Input {
 
     // Calculate the happiness values. Note that the values are not reciprocal a => b != b => a.
     let stride = indices.len();
-    let mut happiness = vec![0; stride * stride];
+    let mut happiness = vec![0_i16; stride * stride];
 
     for &[from, _, gain_lose, value, .., to, _] in &tokens {
         let start = indices[from];
         let end = indices[to];
         let sign = if gain_lose == "gain" { 1 } else { -1 };
-        let value: i32 = value.signed();
+        let value: i16 = value.signed();
 
         // Add the values together to make the mutual link reciprocal.
         happiness[stride * start + end] += sign * value;
@@ -48,38 +52,60 @@ pub fn parse(input: &str) -> Input {
     }
 
     // Solve both parts simultaneously.
-    let mut part_one = 0;
-    let mut part_two = 0;
-    let mut indices: Vec<_> = (1..stride).collect();
+    // Initialize a shared table for both parts: 2ⁿ sets with n distances per set. Default 0 matches
+    // g({k},k) for all singleton sets of zero distance from yourself, but tracking k as the start
+    // of the path. The initial value of other sets does not matter.
+    let zero = (0_i16, 0_u8);
+    let mut table = vec![zero; stride * (1 << stride)];
+    for k in 0..stride {
+        table[(1 << k) * stride + k].1 = k as u8;
+    }
 
-    indices.half_permutations(|slice| {
-        let mut sum = 0;
-        let mut weakest_link = i32::MAX;
-
-        let mut link = |from, to| {
-            let value = happiness[stride * from + to];
-            sum += value;
-            weakest_link = weakest_link.min(value);
-        };
-
-        link(0, slice[0]);
-        link(0, slice[slice.len() - 1]);
-
-        for i in 1..slice.len() {
-            link(slice[i], slice[i - 1]);
+    // Visit each non-empty set in order, with no work to do for singleton sets. Start from 3,
+    // since 1 and 2 are singleton sets.
+    for set in 3_usize..(1 << stride) {
+        if set.is_power_of_two() {
+            continue;
         }
 
-        part_one = part_one.max(sum);
-        part_two = part_two.max(sum - weakest_link);
-    });
+        // For a given set, compute each g(set,k) for all k in the set.
+        for k in set.biterator() {
+            let subset = set ^ (1 << k);
+            let mut longest = i16::MIN;
+            let mut start = u8::MAX;
+
+            // For a given destination k, find which other bit m gives the best path from the
+            // subset to m, and then m to k. All table[subset] references were filled in prior
+            // iterations of the outer loop or the singleton base cases.
+            for m in subset.biterator() {
+                let prior = table[subset * stride + m];
+                let distance = prior.0 + happiness[m * stride + k];
+                if distance > longest {
+                    longest = distance;
+                    start = prior.1;
+                }
+            }
+            table[set * stride + k] = (longest, start);
+        }
+    }
+
+    // With the sets now built, we have stride candidates for each answer.
+    // Part one requires completing the cycle back to the stashed first element.
+    // Part two can be directly read off the table.
+    let mut part_one = i16::MIN;
+    let mut part_two = i16::MIN;
+    for (k, &prior) in table[table.len() - stride..].iter().enumerate() {
+        part_one = part_one.max(prior.0 + happiness[prior.1 as usize * stride + k]);
+        part_two = part_two.max(prior.0);
+    }
 
     (part_one, part_two)
 }
 
-pub fn part1(input: &Input) -> i32 {
+pub fn part1(input: &Input) -> i16 {
     input.0
 }
 
-pub fn part2(input: &Input) -> i32 {
+pub fn part2(input: &Input) -> i16 {
     input.1
 }

--- a/src/year2016/day24.rs
+++ b/src/year2016/day24.rs
@@ -1,29 +1,28 @@
 //! # Air Duct Spelunking
 //!
-//! This is a variant of the classic
-//! [Travelling Salesman Problem](https://en.wikipedia.org/wiki/Travelling_salesman_problem) and
-//! is similar to [`Year 2015 Day 13`].
+//! This is a variant of the classic [Travelling Salesman Problem] and is similar to
+//! [`Year 2015 Day 13`].
 //!
 //! We first simplify the problem by finding the distance between all locations using multiple
 //! [BFS](https://en.wikipedia.org/wiki/Breadth-first_search)
 //! searches starting from each location.
 //!
-//! For speed we convert each location into an index, then store the distances between
-//! every pair of locations in a vec for fast lookup. Our utility [`half_permutations`] method uses
-//! [Steinhaus-Johnson-Trotter's algorithm](https://en.wikipedia.org/wiki/Steinhaus-Johnson-Trotter_algorithm) for efficiency,
-//! modifying the slice in place.
+//! Then we can use [Held-Karp's dynamic programming][Held-Karp] algorithm to determine the
+//! shortest cycle. The problem asks us to start from node 0, which conveniently means that the
+//! value g(127, k) is the shortest path to k, and adding the distance from k back to 0 for part 2
+//! is also trivial. Thus, this day completes with only `7*6/2*128/2` or 1,344 comparisons, quite a
+//! bit better than the 2,520 comparisons needed for an approach with 7!/2 permutations. A
+//! slight complication is that set bit 0 maps to node 1.
 //!
-//! There are 8 locations, however since we always start at `0` this requires checking only
-//! 7!/2 = 2,520 permutations. We find the answer to both part one and two simultaneously.
-//!
-//! [`half_permutations`]: crate::util::slice
 //! [`Year 2015 Day 13`]: crate::year2015::day13
+//! [Travelling Salesman Problem]: https://en.wikipedia.org/wiki/Travelling_salesman_problem
+//! [Held-Karp]: https://en.wikipedia.org/wiki/Held%E2%80%93Karp_algorithm
+use crate::util::bitset::*;
 use crate::util::grid::*;
 use crate::util::parse::*;
-use crate::util::slice::*;
 use std::collections::VecDeque;
 
-type Input = (u32, u32);
+type Input = (u16, u16);
 
 pub fn parse(input: &str) -> Input {
     let grid = Grid::parse(input);
@@ -77,26 +76,53 @@ pub fn parse(input: &str) -> Input {
     }
 
     // Solve both parts simultaneously.
-    let mut part_one = u32::MAX;
-    let mut part_two = u32::MAX;
-    let mut indices: Vec<_> = (1..found.len()).collect();
+    // Initialize a table for each part: 2ⁿ⁻¹ sets with n-1 distances per set. Default each g({k},k)
+    // singleton to distance[0][k+1] (since bit 0 maps to node 1), while the initial value of other
+    // sets does not matter.
+    let mut table = [[0_u16; 7]; 1 << 7];
+    for k in 0..found.len() - 1 {
+        table[1 << k][k] = distance[0][k + 1];
+    }
 
-    indices.half_permutations(|slice| {
-        let first = distance[0][slice[0]];
-        let middle = slice.array_windows().map(|&[from, to]| distance[from][to]).sum::<u32>();
-        let last = distance[slice[slice.len() - 1]][0];
+    // Visit each non-empty set in order, with no work to do for singleton sets. Start from 3,
+    // since 1 and 2 are singleton sets.
+    for set in 3_usize..(1 << (found.len() - 1)) {
+        if set.is_power_of_two() {
+            continue;
+        }
 
-        part_one = part_one.min(first + middle).min(middle + last);
-        part_two = part_two.min(first + middle + last);
-    });
+        // For a given set, compute each g(set,k) for all k in the set.
+        for k in set.biterator() {
+            let subset = set ^ (1 << k);
+            let mut shortest = u16::MAX;
+
+            // For a given destination k, find which other bit m gives the best path from the
+            // subset to m, and then m to k. All table[subset] references were filled in prior
+            // iterations of the outer loop or the singleton base cases.
+            for m in subset.biterator() {
+                shortest = shortest.min(table[subset][m] + distance[m + 1][k + 1]);
+            }
+            table[set][k] = shortest;
+        }
+    }
+
+    // With the sets now built, we have 7 candidates for each answer.
+    let mut part_one = u16::MAX;
+    let mut part_two = u16::MAX;
+    for (k, &path_len) in
+        table[(1 << (found.len() - 1)) - 1].iter().take(found.len() - 1).enumerate()
+    {
+        part_one = part_one.min(path_len);
+        part_two = part_two.min(path_len + distance[k + 1][0]);
+    }
 
     (part_one, part_two)
 }
 
-pub fn part1(input: &Input) -> u32 {
+pub fn part1(input: &Input) -> u16 {
     input.0
 }
 
-pub fn part2(input: &Input) -> u32 {
+pub fn part2(input: &Input) -> u16 {
     input.1
 }


### PR DESCRIPTION
## Description

Experiment with a different algorithm for finding the shortest path, using O(n^2*2^n) rather than O(n!) work.  For a given part, the old code had 2520 callbacks from half_permutations with 8 calls to .max per callback; the new code has only 3584 total calls to .max, and with less overhead than what permutations required for shuffling data around.

I would have loved to have iterated on 3..127 instead of 3..255; that produces only 1344 calls to .max, but only works on inputs where dropping the shortest edge from the longest cycle still produces the longest path.

On my laptop, performance improves from about 40us to 12us. I also tried separating the two tables (doing Held-Karp in part1() and part2() rather than joint iteration in parse(), but that had more overhead with duplicated set traversal.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
