### PR TITLE
Use shorter springdroid script

### DIFF
--- a/src/year2019/day21.rs
+++ b/src/year2019/day21.rs
@@ -1,7 +1,9 @@
 //! # Springdroid Adventure
 //!
 //! Jumps are always 4 tiles wide, landing on `D`. If needed we can jump again immediately
-//! landing on `H`.
+//! landing on `H`. The intcode program runs faster if the springscript is shorter, so although
+//! multiple scripts work, any solution that treats intcode as a black box will be better if
+//! the script is minimized.
 //!
 //! ## Part One
 //!
@@ -15,16 +17,21 @@
 //!
 //! `J = NOT (A AND B AND C) AND D`
 //!
+//! But in practice, all input files are set up so that part 1 passes even when we never
+//! probe `B`, simplifying to 4 instructions:
+//!
+//! `J = NOT (A AND C) AND D`
+//!
 //! ## Part Two
 //!
-//! We add two rules, either `H` needs to be ground so that we double jump immediately or `E`
-//! needs to be ground, so that we can wait and not jump too early.
+//! Now `B` matters, and we also need a new rule to jump if `H` is ground when `C` is a hole,
+//! to trigger a double jump. This can be done in 6 instructions. Suprisingly, we never needed
+//! to use register `T`.
 use super::intcode::*;
 use crate::util::parse::*;
 
 const WALK: &str = "\
 OR A J
-AND B J
 AND C J
 NOT J J
 AND D J
@@ -32,14 +39,12 @@ WALK
 ";
 
 const RUN: &str = "\
-OR A J
+NOT H J
+OR C J
 AND B J
-AND C J
+AND A J
 NOT J J
 AND D J
-OR E T
-OR H T
-AND T J
 RUN
 ";
 


### PR DESCRIPTION
## Description

Every line of springdroid script causes that much more execution time for the intcode program (looking at Eric's sample source code [1], it blindly executes a sequence of intcode instructions for every compiled line of springscript on every bit of each 9-bit hole pattern, even if extra script instructions don't change the final contents of register J). In tracing things, I see about 50k fewer Intcode opcodes executed for each line of springdroid eliminated.  Thus, coming up with a shorter program that still passes all inputs is worthwhile.

[1] https://github.com/topaz/aoc2019-intcode/blob/master/samples/day21.intcode

On my laptop, runtime improved from 145us/3.4ms for part1/part2 pre-patch, to 125us/2.8ms post-patch.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
