### PR TITLE
Use A* search for less overall work

### DIFF
--- a/src/year2019/day18.rs
+++ b/src/year2019/day18.rs
@@ -69,14 +69,18 @@ struct Door {
     needed: u32,
 }
 
+type Matrix = [[Door; 30]; 30];
+
 /// `initial` is the complete set of keys that we need to collect. Will always be binary
 /// `11111111111111111111111111` for the real input but fewer for sample data.
 ///
-/// `maze` is the adjacency matrix of distances and doors between each pair of keys and the
-/// robots' starting locations.
+/// `masks` maps the set of keys in the same quadrant, for prefiltering in part 2.
+/// `matrix` is the adjacency of distances and doors between each pair of keys and the robots'
+/// starting locations.
 struct Maze {
     initial: State,
-    maze: [[Door; 30]; 30],
+    masks: [u32; 30],
+    matrix: Matrix,
 }
 
 pub fn parse(input: &str) -> Grid<u8> {
@@ -124,9 +128,10 @@ fn parse_maze(width: usize, bytes: &[u8]) -> Maze {
     // As a minor optimization we reuse the same `todo` and `seen` between each search.
     let default = Door { distance: u32::MAX, needed: 0 };
 
-    let mut maze = [[default; 30]; 30];
+    let mut matrix = [[default; 30]; 30];
     let mut seen = vec![usize::MAX; bytes.len()];
     let mut todo = VecDeque::new();
+    let mut masks = [0; 30];
 
     for (start, from) in found {
         todo.push_front((start, 0, 0));
@@ -141,8 +146,10 @@ fn parse_maze(width: usize, bytes: &[u8]) -> Maze {
                 && distance > 0
             {
                 // Store the reciprocal edge weight and doors in the adjacency matrix.
-                maze[from][to] = Door { distance, needed };
-                maze[to][from] = Door { distance, needed };
+                matrix[from][to] = Door { distance, needed };
+                matrix[to][from] = Door { distance, needed };
+                masks[from] |= 1 << to;
+                masks[to] |= 1 << from;
                 // Faster to stop here and use Floyd-Warshall later.
                 continue;
             }
@@ -159,31 +166,33 @@ fn parse_maze(width: usize, bytes: &[u8]) -> Maze {
     // Fill in the rest of the graph using the Floyd-Warshall algorithm.
     // As a slight twist we also build the list of intervening doors at the same time.
     for i in RANGE {
-        maze[i][i].distance = 0;
+        matrix[i][i].distance = 0;
     }
 
     for k in RANGE {
         for i in RANGE {
             for j in RANGE {
-                let candidate = maze[i][k].distance.saturating_add(maze[k][j].distance);
-                if maze[i][j].distance > candidate {
-                    maze[i][j].distance = candidate;
+                let candidate = matrix[i][k].distance.saturating_add(matrix[k][j].distance);
+                if matrix[i][j].distance > candidate {
+                    matrix[i][j].distance = candidate;
                     // `(1 << k)` is a crucial optimization. By treating intermediate keys like
                     // doors we speed things up by a factor of 30.
-                    maze[i][j].needed = maze[i][k].needed | (1 << k) | maze[k][j].needed;
+                    matrix[i][j].needed = matrix[i][k].needed | (1 << k) | matrix[k][j].needed;
+                    masks[i] |= 1 << j;
+                    masks[j] |= 1 << i;
                 }
             }
         }
     }
 
-    Maze { initial, maze }
+    Maze { initial, masks, matrix }
 }
 
 fn explore(width: usize, bytes: &[u8]) -> u32 {
     let mut todo = MinHeap::with_capacity(5_000);
     let mut cache = FastMap::with_capacity(5_000);
 
-    let Maze { initial, maze } = parse_maze(width, bytes);
+    let Maze { initial, masks, matrix } = parse_maze(width, bytes);
     todo.push(0, initial);
 
     while let Some((total, State { position, remaining })) = todo.pop() {
@@ -193,14 +202,22 @@ fn explore(width: usize, bytes: &[u8]) -> u32 {
             return total;
         }
 
+        // Avoid next-neighbor checks if this state was visited in the meantime by a better path.
+        if let Some(&best) = cache.get(&State { position, remaining })
+            && total > best
+        {
+            continue;
+        }
+
         // The set of robots is stored as bits in a `u32` shifted by the index of the location.
         for from in position.biterator() {
             // The set of keys still needed is also stored as bits in a `u32` similarly to robots.
-            for to in remaining.biterator() {
-                let Door { distance, needed } = maze[from][to];
+            // Filter the list of destinations to keys in the same quadrant.
+            for to in (remaining & masks[from]).biterator() {
+                let Door { distance, needed } = matrix[from][to];
 
-                // u32::MAX indicates that two nodes are not connected. Only possible in part two.
-                if distance != u32::MAX && remaining & needed == 0 {
+                // Don't move to a key that still has unmet dependencies.
+                if remaining & needed == 0 {
                     let next_total = total + distance;
                     let from_mask = 1 << from;
                     let to_mask = 1 << to;

--- a/src/year2019/day18.rs
+++ b/src/year2019/day18.rs
@@ -7,10 +7,15 @@
 //!
 //! We first find the distance between every pair of keys then run the
 //! [A* algorithm](https://en.wikipedia.org/wiki/A*_search_algorithm) to find the
-//! shortest path that visits every node in the graph. The heuristic is the sum of the minimum
-//! possible distances to reach every remaining key, which helps the search focus on the
-//! overall minimum rather than the nearest key, for fewer nodes explored. Since the heuristic
-//! is consistent, no node will ever ever have its score reduced after the first visit.
+//! shortest path that visits every node in the graph. One heuristic is a constant-time query
+//! of the sum of the minimum path length out of all remaining keys (updated by subtraction
+//! as a key is visited), which works well for part one when there is only one robot that must
+//! visit every remaining node, but underestimates for part two. Another heuristic is a cacheable
+//! linear-time query of the maximum distance each robot must travel to reach the furthest remaining
+//! key. This latter query is expensive enough that it penalizes part one, but its improved accuracy
+//! prunes more states in part two than the extra time spent on computing the heuristic. Both
+//! heuristics reach zero at the goal, and are consistent, meaning they never overestimate and no
+//! state will lower its score after the initial visit.
 //!
 //! The maze is also constructed in such a way to make our life easier:
 //! * There is only ever one possible path to each key. We do not need to consider
@@ -78,7 +83,7 @@ type Matrix = [[Door; 30]; 30];
 /// `11111111111111111111111111` for the real input but fewer for sample data.
 ///
 /// `masks` maps the set of keys in the same quadrant, for prefiltering in part 2.
-/// `minimum` is the smallest distance from a key to any of its neighbors, for the A* heuristic.
+/// `minimum` is the smallest distance from a key to any of its neighbors, for the part1 heuristic.
 /// `matrix` is the adjacency of distances and doors between each pair of keys and the robots'
 /// starting locations.
 struct Maze {
@@ -93,7 +98,8 @@ pub fn parse(input: &str) -> Grid<u8> {
 }
 
 pub fn part1(input: &Grid<u8>) -> u32 {
-    explore(input.width as usize, &input.bytes)
+    // Select the O(1) A* heuristic, since there is only one robot visiting all keys.
+    explore::<false>(input.width as usize, &input.bytes)
 }
 
 pub fn part2(input: &Grid<u8>) -> u32 {
@@ -108,7 +114,8 @@ pub fn part2(input: &Grid<u8>) -> u32 {
     patch("###", 0);
     patch("@#@", 1);
 
-    explore(input.width as usize, &modified)
+    // Select the O(n) A* heuristic, since each robot vists about one-fourth of the keys.
+    explore::<true>(input.width as usize, &modified)
 }
 
 fn parse_maze(width: usize, bytes: &[u8]) -> Maze {
@@ -196,16 +203,21 @@ fn parse_maze(width: usize, bytes: &[u8]) -> Maze {
     Maze { initial, masks, minimum, matrix }
 }
 
-fn explore(width: usize, bytes: &[u8]) -> u32 {
+// Same algorithm, but specialized on which heuristic to use.
+fn explore<const PART_TWO: bool>(width: usize, bytes: &[u8]) -> u32 {
     let mut todo = MinHeap::with_capacity(5_000);
-    let mut cache = FastMap::with_capacity(5_000);
+    let mut state_cache = FastMap::with_capacity(5_000);
+    let mut heur_cache = FastMap::with_capacity(5_000);
 
     let Maze { initial, masks, minimum, matrix } = parse_maze(width, bytes);
-    let heuristic: u32 = minimum.iter().filter(|&min| *min < u32::MAX).sum();
-    todo.push(heuristic, (initial, heuristic));
+    let heur = if PART_TWO {
+        heuristic(initial, &masks, &matrix, &mut heur_cache)
+    } else {
+        minimum.iter().filter(|&min| *min < u32::MAX).sum()
+    };
+    todo.push(heur, (initial, 0));
 
-    while let Some((guess, (State { position, remaining }, heuristic))) = todo.pop() {
-        let total = guess - heuristic;
+    while let Some((guess, (State { position, remaining }, total))) = todo.pop() {
         // Finish immediately if no keys left.
         // Since we're using A* with a consistent heuristic this will always be the optimal solution.
         if remaining == 0 {
@@ -213,7 +225,7 @@ fn explore(width: usize, bytes: &[u8]) -> u32 {
         }
 
         // Avoid next-neighbor checks if this state was visited in the meantime by a better path.
-        if let Some(&best) = cache.get(&State { position, remaining })
+        if let Some(&best) = state_cache.get(&State { position, remaining })
             && total > best
         {
             continue;
@@ -237,12 +249,16 @@ fn explore(width: usize, bytes: &[u8]) -> u32 {
                     };
 
                     // Memoize previously seen states to eliminate suboptimal states right away.
-                    let best = cache.entry(next_state).or_insert(u32::MAX);
+                    let best = state_cache.entry(next_state).or_insert(u32::MAX);
                     if next_total < *best {
                         *best = next_total;
-                        let next_heuristic = heuristic - minimum[to];
-                        let next_guess = next_total + next_heuristic;
-                        todo.push(next_guess, (next_state, next_heuristic));
+                        let next_heur = if PART_TWO {
+                            heuristic(next_state, &masks, &matrix, &mut heur_cache)
+                        } else {
+                            guess - total - minimum[to]
+                        };
+                        let next_guess = next_total + next_heur;
+                        todo.push(next_guess, (next_state, next_total));
                     }
                 }
             }
@@ -259,4 +275,26 @@ fn is_key(b: u8) -> Option<usize> {
 
 fn is_door(b: u8) -> Option<usize> {
     b.is_ascii_uppercase().then(|| (b - b'A') as usize)
+}
+
+// Compute part two heuristic of the sum of the furthest key remaining per robot. For part one,
+// rely on the faster but weaker O(1) tracking of the sum of all minimum legs.
+fn heuristic(
+    state: State,
+    masks: &[u32],
+    matrix: &Matrix,
+    cache: &mut FastMap<(usize, u32), u32>,
+) -> u32 {
+    let mut heur = 0;
+
+    for bot in state.position.biterator() {
+        let reachable = state.remaining & masks[bot];
+
+        let dist = *cache.entry((bot, reachable)).or_insert_with(|| {
+            reachable.biterator().map(|key| matrix[bot][key].distance).max().unwrap_or(0)
+        });
+
+        heur += dist;
+    }
+    heur
 }

--- a/src/year2019/day18.rs
+++ b/src/year2019/day18.rs
@@ -5,9 +5,12 @@
 //! keys and the edge weight is the distance between keys. Doors modify which edges
 //! are connected depending on the keys currently possessed.
 //!
-//! We first find the distance between every pair of keys then run
-//! [Dijkstra's algorithm](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm) to find the
-//! shortest path that visits every node in the graph.
+//! We first find the distance between every pair of keys then run the
+//! [A* algorithm](https://en.wikipedia.org/wiki/A*_search_algorithm) to find the
+//! shortest path that visits every node in the graph. The heuristic is the sum of the minimum
+//! possible distances to reach every remaining key, which helps the search focus on the
+//! overall minimum rather than the nearest key, for fewer nodes explored. Since the heuristic
+//! is consistent, no node will ever ever have its score reduced after the first visit.
 //!
 //! The maze is also constructed in such a way to make our life easier:
 //! * There is only ever one possible path to each key. We do not need to consider
@@ -75,11 +78,13 @@ type Matrix = [[Door; 30]; 30];
 /// `11111111111111111111111111` for the real input but fewer for sample data.
 ///
 /// `masks` maps the set of keys in the same quadrant, for prefiltering in part 2.
+/// `minimum` is the smallest distance from a key to any of its neighbors, for the A* heuristic.
 /// `matrix` is the adjacency of distances and doors between each pair of keys and the robots'
 /// starting locations.
 struct Maze {
     initial: State,
     masks: [u32; 30],
+    minimum: [u32; 30],
     matrix: Matrix,
 }
 
@@ -132,6 +137,7 @@ fn parse_maze(width: usize, bytes: &[u8]) -> Maze {
     let mut seen = vec![usize::MAX; bytes.len()];
     let mut todo = VecDeque::new();
     let mut masks = [0; 30];
+    let mut minimum = [u32::MAX; 30];
 
     for (start, from) in found {
         todo.push_front((start, 0, 0));
@@ -150,6 +156,8 @@ fn parse_maze(width: usize, bytes: &[u8]) -> Maze {
                 matrix[to][from] = Door { distance, needed };
                 masks[from] |= 1 << to;
                 masks[to] |= 1 << from;
+                minimum[from] = minimum[from].min(distance);
+                minimum[to] = minimum[to].min(distance);
                 // Faster to stop here and use Floyd-Warshall later.
                 continue;
             }
@@ -185,19 +193,21 @@ fn parse_maze(width: usize, bytes: &[u8]) -> Maze {
         }
     }
 
-    Maze { initial, masks, matrix }
+    Maze { initial, masks, minimum, matrix }
 }
 
 fn explore(width: usize, bytes: &[u8]) -> u32 {
     let mut todo = MinHeap::with_capacity(5_000);
     let mut cache = FastMap::with_capacity(5_000);
 
-    let Maze { initial, masks, matrix } = parse_maze(width, bytes);
-    todo.push(0, initial);
+    let Maze { initial, masks, minimum, matrix } = parse_maze(width, bytes);
+    let heuristic: u32 = minimum.iter().filter(|&min| *min < u32::MAX).sum();
+    todo.push(heuristic, (initial, heuristic));
 
-    while let Some((total, State { position, remaining })) = todo.pop() {
+    while let Some((guess, (State { position, remaining }, heuristic))) = todo.pop() {
+        let total = guess - heuristic;
         // Finish immediately if no keys left.
-        // Since we're using Dijkstra this will always be the optimal solution.
+        // Since we're using A* with a consistent heuristic this will always be the optimal solution.
         if remaining == 0 {
             return total;
         }
@@ -230,7 +240,9 @@ fn explore(width: usize, bytes: &[u8]) -> u32 {
                     let best = cache.entry(next_state).or_insert(u32::MAX);
                     if next_total < *best {
                         *best = next_total;
-                        todo.push(next_total, next_state);
+                        let next_heuristic = heuristic - minimum[to];
+                        let next_guess = next_total + next_heuristic;
+                        todo.push(next_guess, (next_state, next_heuristic));
                     }
                 }
             }


### PR DESCRIPTION
## Description

The search can be steered towards the global minimum by pre-computing a heuristic of the absolute minimum possible distance that each key can contribute, then updating that heuristic with a subtraction per key visited, making it a nice lightweight O(1) heuristic.  By the time we reach the goal of zero keys remaining, the heuristic also reaches zero, so it is consistent and we do not have to worry about revisiting a node with a lower distance from an alternative path.  Then, using an O(n) heuristic for part 2 (but not part 1) got even more speed by pruning much more of the search space.

On my laptop, this improves runtimes dramtically, even if the numbers are a bit noisy.  A more direct analysis, by instrumenting the number of cache accesses and items of work processed when using my input file, shows that part 2 sees the bigger benefit:

```
                        cache.entry()  todo.push()  todo.pop() runtime
    part 1 pre-series    101494         23195        22762      5.2ms
    part 1 post-series    65546         23019        21410      4.6ms
    part 2 pre-series    120813         33238        31437     12.1ms
    part 2 post-series    33577         13826         6689      2.3ms
```

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
