### PR TITLE
Steer network traffic to speed up part two computation

### DIFF
--- a/src/year2019/day23.rs
+++ b/src/year2019/day23.rs
@@ -3,6 +3,26 @@
 //! Solves both part one and two simultaneously. A nice benefit of our intcode computer is that it
 //! returns [`State::Input`] when the input queue is empty, making it easy to detect an
 //! idle network.
+//!
+//! Analysis of the network of 50 programs shows that each program id has a fixed number of
+//! input slots, with slots addressed by (packetx/constant)-1 with different constants per id,
+//! where the program stores packety. Once all slots are filled, a given program will either
+//! copy, add, multiply, or divide the input slots and then fan out the result to a hardcoded
+//! list of other programs any time a changed input results in a changed output. The connections
+//! between programs form a directed acyclic graph (DAG), and the first output to 255 (the part
+//! one answer) occurs only after all nodes have filled all input slots. Thereafter, feeding
+//! the 255 result to node 0 triggers a wave of updates through other nodes. The overall network
+//! is computing a cubic function `f(x) = (x - C1)*((x - C1)² - 300000000) / 1000000000 + x`
+//! where each input to node 0 is a new x value that eventually causes f(x) to be output to node
+//! 255. Since the network stabilizes at the fixed point when `f(x) == x`, the goal boils down
+//! to computing the fixed point C1.
+//!
+//! We can use this knowledge to speed up part two: instead of multiple rounds of computing f(x)
+//! on the value produced in the previous round, and waiting for things to converge, we can instead
+//! trigger the start the computation of f(1) on node zero, use that to learn the id that processes
+//! the x² term along with the magic numbers needed to populate its slots, then grab the output
+//! of that node. We are guaranteed by how the cubic function was set up that the output of that
+//! second node is -3 times C1, the answer we want.
 use super::intcode::*;
 use crate::util::parse::*;
 
@@ -10,10 +30,13 @@ type Input = (i64, i64);
 
 pub fn parse(input: &str) -> Input {
     let code: Vec<_> = input.iter_signed().collect();
+    let mut todo = Vec::with_capacity(50);
     let mut network: Vec<_> = (0..50)
         .map(|address| {
             let mut computer = Computer::new(&code);
             computer.input(address);
+            computer.input(-1);
+            todo.push(address);
             computer
         })
         .collect();
@@ -21,17 +44,13 @@ pub fn parse(input: &str) -> Input {
     let mut sent = Vec::new();
     let mut nat_x = 0;
     let mut nat_y = 0;
-    let mut first_y = None;
-    let mut idle_y = None;
 
-    loop {
-        let mut index = 0;
-        let mut empty = 0;
-
-        while index < 50 {
-            let computer = &mut network[index];
-
-            match computer.run() {
+    // Run the network until todo is empty, at which point part 1 is available as nat_y. This
+    // also gives us nat_x, which is magic number needed to pass input to node 0.
+    while let Some(index) = todo.pop() {
+        // Run an individual computer until it blocks for more input.
+        loop {
+            match network[index as usize].run() {
                 State::Output(value) => {
                     // Loop until we have accumulated a full packet of 3 values.
                     sent.push(value);
@@ -42,39 +61,56 @@ pub fn parse(input: &str) -> Input {
 
                     if address == 255 {
                         // Handle part one.
-                        first_y.get_or_insert(y);
                         nat_x = x;
                         nat_y = y;
                     } else {
                         let destination = &mut network[address as usize];
                         destination.input(x);
                         destination.input(y);
+                        todo.push(address);
                     }
                 }
                 // Input queue is empty.
                 State::Input => {
-                    empty += 1;
-                    computer.input(-1);
+                    break;
                 }
                 State::Halted => unreachable!(),
             }
-
-            index += 1;
-        }
-
-        if empty == 50 {
-            if idle_y == Some(nat_y) {
-                break;
-            }
-            idle_y = Some(nat_y);
-
-            let destination = &mut network[0];
-            destination.input(nat_x);
-            destination.input(nat_y);
         }
     }
 
-    (first_y.unwrap(), idle_y.unwrap())
+    // Instead of feeding nat_y to node 0, feed 1 to force the computation of f(1). Node 0 has
+    // six output triples: first to the node in charge of the x term, then two to the node for x²,
+    // and finally three to node for x³. We only need the inputs to the x² node.
+    let mut next_computer = 0;
+    network[0].input(nat_x);
+    network[0].input(1);
+    for _ in 0..9 {
+        match network[0].run() {
+            State::Output(value) => {
+                // Loop until we have accumulated 3 triples.
+                sent.push(value);
+                let [address, x, y] = sent[..] else {
+                    continue;
+                };
+                sent.clear();
+
+                let destination = &mut network[address as usize];
+                destination.input(x);
+                destination.input(y);
+                next_computer = address as usize;
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    // Now run the x² node until its second output triple, which is -3 times the fixed point.
+    let mut last_sent = 0;
+    while let State::Output(value) = network[next_computer].run() {
+        last_sent = value;
+    }
+
+    (nat_y, last_sent / -3)
 }
 
 pub fn part1(input: &Input) -> i64 {


### PR DESCRIPTION
## Description

Black-box analysis[1] of the day 23 program shows that each id uses a jump table to run a hard-coded machine that has several parameters: a number of input slots, a magic number used to address those slots, an operation (copy, add, multiply, or divide), and a number of fanouts that are triggered once the first -1 and all input slots have been read.  Furthermore, the 50 ids are wired up in a DAG where exactly one machine outputs to 255 after all other machines have stabilized, and where every subsequent write to id 0 triggers a cascade of updates among the nodes to recompute the value of a cubic equation. Since the network computes f(x)=ax^3 + bx^2 + cx + d, and we are running the output f(x) back as the new input x for the next cycle, we are searching for a fixed point of the cubic.  Running f(1) and inspecting b gives us the same answer with much less work.

On my machine, this cuts runtime from 1.9ms to 750us.

[1] https://www.reddit.com/r/adventofcode/comments/een9mk/2019_day_23_part_2_what_is_the_network_computing/

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
