### PR TITLE
Speed up 2025/day05 10% with guard entries and single pass part1 scan

### DIFF
--- a/src/year2025/day05.rs
+++ b/src/year2025/day05.rs
@@ -22,29 +22,33 @@ pub fn parse(input: &str) -> Input {
     let mut part1 = 0;
 
     ranges.sort_unstable();
-    ranges.push([u64::MAX,u64::MAX]);  // Guard!
+    ranges.push([u64::MAX, u64::MAX]); // Guard!
 
     let mut start = ranges[0][0];
-    let mut end = ranges[0][1]+1;
+    let mut end = ranges[0][1] + 1;
 
     // Merge ranges together.
-    for r in 1..ranges.len() {
-        if ranges[r][0] < end {
-            end = end.max(ranges[r][1] + 1);
+    for [from, to] in ranges.iter().skip(1) {
+        if *from < end {
+            end = end.max(*to + 1);
         } else {
-            part2 += end-start;
-            merged.push([start,end]);
-            start = ranges[r][0];
-            end = ranges[r][1];
+            part2 += end - start;
+            merged.push([start, end]);
+            start = *from;
+            end = *to+1;
         }
     }
-    merged.push([start,end]); // This is the zero length guard range greater than any id
+    merged.push([u64::MAX, u64::MAX]); // This is the zero length guard range greater than any id
 
     ids.sort_unstable();
     let mut r = 0;
     for ii in ids {
-        while ii >= merged[r][1] {r += 1;}
-        if ii >= merged[r][0] { part1 += 1;}
+        while ii >= merged[r][1] {
+            r += 1;
+        }
+        if ii >= merged[r][0] {
+            part1 += 1;
+        }
     }
     (part1, part2)
 }

--- a/src/year2025/day05.rs
+++ b/src/year2025/day05.rs
@@ -4,49 +4,55 @@
 //! complexity by first sorting the ranges in ascending order of their start.
 //!
 //! Interestingly, part one is harder than part two. We could check every ID against every range,
-//! however this is slow. It's much faster instead to first sort IDs in ascending order,
-//! then for each range use a [binary search](https://en.wikipedia.org/wiki/Binary_search) to count
-//! the number of IDs that it contains. Rust even provides a handy built-in
-//! [`binary_search`] method on slices.
+//! however this is slow. It's much faster to sort IDs in ascending order,
+//! just like the ranges, so that a single O(n) pass can check all of them
 //!
-//! [`binary_search`]: https://doc.rust-lang.org/std/primitive.slice.html#method.binary_search
 use crate::util::iter::*;
 use crate::util::parse::*;
-use std::ops::Range;
+// use std::ops::Range;
 
-type Input = (Vec<Range<u64>>, Vec<u64>);
+type Input = (usize, u64);
 
 pub fn parse(input: &str) -> Input {
     let (prefix, suffix) = input.split_once("\n\n").unwrap();
     let mut ranges: Vec<_> = prefix.iter_unsigned().chunk::<2>().collect();
-    let mut ids: Vec<_> = suffix.iter_unsigned().collect();
-    let mut range = 0..0;
+    let mut ids: Vec<u64> = suffix.iter_unsigned().collect();
     let mut merged = Vec::new();
+    let mut part2 = 0;
+    let mut part1 = 0;
 
     ranges.sort_unstable();
-    ids.sort_unstable();
+    ranges.push([u64::MAX,u64::MAX]);  // Guard!
+
+    let mut start = ranges[0][0];
+    let mut end = ranges[0][1]+1;
 
     // Merge ranges together.
-    for [from, to] in ranges {
-        if from < range.end {
-            range.end = range.end.max(to + 1);
+    for r in 1..ranges.len() {
+        if ranges[r][0] < end {
+            end = end.max(ranges[r][1] + 1);
         } else {
-            merged.push(range);
-            range = from..to + 1;
+            part2 += end-start;
+            merged.push([start,end]);
+            start = ranges[r][0];
+            end = ranges[r][1];
         }
     }
+    merged.push([start,end]); // This is the zero length guard range greater than any id
 
-    merged.push(range);
-    (merged, ids)
+    ids.sort_unstable();
+    let mut r = 0;
+    for ii in ids {
+        while ii >= merged[r][1] {r += 1;}
+        if ii >= merged[r][0] { part1 += 1;}
+    }
+    (part1, part2)
 }
 
 pub fn part1(input: &Input) -> usize {
-    let (merged, ids) = input;
-    let position = |id: u64| ids.binary_search(&id).unwrap_or_else(|e| e);
-    merged.iter().map(|range| position(range.end) - position(range.start)).sum()
+    input.0
 }
 
 pub fn part2(input: &Input) -> u64 {
-    let (merged, _) = input;
-    merged.iter().map(|range| range.end - range.start).sum()
+    input.1
 }


### PR DESCRIPTION
## Description

Main change is to combine the parsing with both part1 & part2 solve. Both parts use a range guard entry [u64::MAX,u64::MAX] which simplifies the inner logic. Half the speedup is due to the guard entries and half due to inline part1 scanning/inclusion.

## Type of change

- [x] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [x] Pull request title and commit messages are clear and informative.
- [ ] Documentation has been updated if necessary.
- [ ] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [x] Tests pass `cargo test`
- [x] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [x] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
