### PR TITLE
Speed up search for solution

### DIFF
--- a/src/year2019/day02.rs
+++ b/src/year2019/day02.rs
@@ -6,8 +6,8 @@
 //!
 //! We can isolate the value of the constants a, b, c in order to speed up subsequent calculations.
 //!
-//! Since the equation is linear in noun and verb, we can efficiently solve part two by iterating
-//! over possible noun values and computing the corresponding verb directly.
+//! Since the equation is linear in noun and verb, and since a is much larger than b, we can
+//! efficiently solve part two by directly reversing the algebra.
 use crate::util::parse::*;
 
 type Input = [i32; 3];
@@ -26,12 +26,10 @@ pub fn part1([a, b, c]: &Input) -> i32 {
 }
 
 pub fn part2([a, b, c]: &Input) -> i32 {
-    (0..100)
-        .find_map(|x| {
-            let y = (19690720 - a * x - c) / b;
-            (a * x + b * y + c == 19690720 && (0..100).contains(&y)).then_some(100 * x + y)
-        })
-        .unwrap()
+    let goal = 19690720 - c;
+    let x = goal / a;
+    let y = (goal % a) / b;
+    x * 100 + y
 }
 
 fn check(code: &[usize], first: usize, second: usize) -> i32 {


### PR DESCRIPTION
## Description

Rather than iterating over all 100 possible nouns, we can observe that the constant a is much larger than b. In fact, b appears to be 1 in every valid input file (since verb is never multiplied, and is used late enough in the chain that later steps do not double its impact); however, b is larger than 1 in the hand-written
tests/year2019/day02.rs.

Of course, this problem is already fast (under 1us on my machine), but this changes part2 from 100ns to 5ns.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
