### PR TITLE
Solve puzzle with less inventory churn

### DIFF
--- a/src/year2019/day25.rs
+++ b/src/year2019/day25.rs
@@ -17,7 +17,7 @@
 //! Just for fun this solution can be played interactively on the command line if
 //! "--features frivolity" is enabled.
 use super::intcode::*;
-use crate::util::hash::*;
+use crate::util::bitset::*;
 use crate::util::parse::*;
 use std::fmt::Write as _;
 
@@ -108,42 +108,45 @@ fn play_automatically(input: &[i64]) -> String {
     // If we are adding an item to a collection that is already too heavy or vice-versa,
     // then we can skip the pressure plate check.
     let combinations: u32 = 1 << inventory.len();
+    let mut have = combinations - 1;
+    let mut want = have;
     let mut output = String::new();
-    let mut too_light = FastSet::new();
-    let mut too_heavy = FastSet::new();
+    let mut too_light = Vec::with_capacity(combinations as usize);
+    let mut too_heavy = Vec::with_capacity(combinations as usize);
 
-    for i in 1..combinations {
+    'outer: for i in 1..combinations {
         let current = gray_code(i);
         let previous = gray_code(i - 1);
         let changed = current ^ previous;
-        let index = changed.trailing_zeros() as usize;
 
         // Since we start with all items in our possession, the meaning of bits in the Gray code is
-        // reversed. 0 is take an item and 1 is drop an item.
-        if current & changed == 0 {
-            take_item(&mut computer, &inventory[index]);
-
-            if too_heavy.contains(&previous) {
-                too_heavy.insert(current);
-                continue;
+        // reversed. 0 is take an item and 1 is drop an item. Iterating over too_heavy and
+        // too_light is still cheaper than the cost to emulate another take or drop, so it is worth
+        // seeing if we can skip altering inventory to a given configuration.
+        want ^= changed;
+        for heavy in &too_heavy {
+            if (want & heavy) == *heavy {
+                // Want is a superset of a known heavy configuration.
+                continue 'outer;
             }
-        } else {
-            drop_item(&mut computer, &inventory[index]);
-
-            if too_light.contains(&previous) {
-                too_light.insert(current);
-                continue;
+        }
+        for light in &too_light {
+            if (want & light) == want {
+                // Want is a subset of a known light configuration.
+                continue 'outer;
             }
         }
 
+        sync_items(&mut computer, have, want, &inventory);
+        have = want;
         if matches!(movement_noisy(&mut computer, &last, &mut output), State::Halted) {
             // Keep only the password digits from Santa's response.
             output.retain(|b| b.is_ascii_digit());
             break;
         } else if output.contains("heavier") {
-            too_light.insert(current);
+            too_light.push(want);
         } else {
-            too_heavy.insert(current);
+            too_heavy.push(want);
         }
 
         output.clear();
@@ -232,6 +235,16 @@ fn take_item(computer: &mut Computer, item: &str) {
 fn drop_item(computer: &mut Computer, item: &str) {
     computer.input_ascii(&format!("drop {item}\n"));
     drain_output(computer);
+}
+
+fn sync_items(computer: &mut Computer, have: u32, want: u32, inventory: &[String]) {
+    for i in (want ^ have).biterator() {
+        if have & (1 << i) != 0 {
+            drop_item(computer, &inventory[i]);
+        } else {
+            take_item(computer, &inventory[i]);
+        }
+    }
 }
 
 // A quirk of the intcode program is that commands can't be stacked. We must first read all the


### PR DESCRIPTION
## Description

Although a Gray code walk can get lucky (I have access to one input file that it solved in just 3 takes, 7 drops, and 7 move attempts; my laptop benchmarked this in 900us), others might not attempt to drop the final item until after traversing through 128 other Gray codes (another input file I tried took 69 takes, 73 drops, and 74 move attempts, and benchmark reports 3.7ms).

However, Intcode emulation is expensive (~1500 instructions for a drop, ~2000 for a take, and ~8500 for a move attempt; where there is some variability depending on the item name length and which in-memory array index the items live at), so anything we can do locally to avoid another Intcode command will likely speed up the overall puzzle.  In this case, we can make two improvements: first, instead of comparing to see if we are a superset or subset of just the previous state (50% of the time, but only checks one adjacent state in the overall hypercube traversal), we can compare against all other settled states (even if the state we are a superset of was walked 32 or 64 steps ago in the Gray code path); minimizing the size of too_heavy and too_light helps keep this check fast, and the result of better pruning is fewer calls to attempt moves.  Second, instead of always changing our current inventory to match the latest Gray code directions, we can defer inventory changes until we lack enough information from superset/subset checks, for fewer calls to take and drop between move attempts.

For the two input files I tested, the faster one remains unchanged at 900us and 3/7/7 take/drop/move, but the slower one improved to 2.8ms and a smaller 38/42/43 actions.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
