### PR TITLE
Larger grid and faster startup for day 17

### DIFF
--- a/src/year2019/day17.rs
+++ b/src/year2019/day17.rs
@@ -14,6 +14,10 @@
 //! Then we look for three patterns that can be repeated in any order to form the whole path.
 //! Without loss of generality the first pattern anchored at the start is always `A`,
 //! the next `B` and the last `C`.
+//!
+//! A good chunk of the Intcode runtime is spent on unpacking compressed memory into the grid
+//! that is first displayed to the user; this effort is the same between both parts. Running the
+//! entire solution in parse thus reduces the overall runtime.
 use super::intcode::*;
 use crate::util::hash::*;
 use crate::util::parse::*;
@@ -23,10 +27,10 @@ use std::iter::once;
 use std::ops::ControlFlow;
 
 pub struct Input {
-    code: Vec<i64>,
     scaffold: FastSet<Point>,
     position: Point,
     direction: Point,
+    score: i64,
 }
 
 struct Movement<'a> {
@@ -36,7 +40,9 @@ struct Movement<'a> {
 
 /// The camera output points from left to right, top to bottom.
 pub fn parse(input: &str) -> Input {
-    let code: Vec<_> = input.iter_signed().collect();
+    // Only run the part two program; its initial output matches part one, and avoiding the
+    // startup costs of a second machine results in a faster solution.
+    let code: Vec<_> = once(2).chain(input.iter_signed().skip(1)).collect();
     let mut computer = Computer::new(&code);
 
     let mut x = 0;
@@ -69,20 +75,10 @@ pub fn parse(input: &str) -> Input {
         x += 1;
     }
 
-    Input { code, scaffold, position, direction }
-}
+    let mut input = Input { scaffold, position, direction, score: 0 };
 
-pub fn part1(input: &Input) -> i32 {
-    input
-        .scaffold
-        .iter()
-        .filter(|&point| ORTHOGONAL.iter().all(|&delta| input.scaffold.contains(&(*point + delta))))
-        .map(|point| point.x * point.y)
-        .sum()
-}
-
-pub fn part2(input: &Input) -> i64 {
-    let path = build_path(input);
+    // With the scaffold now available, construct the compressed path.
+    let path = build_path(&input);
     let mut movement = Movement { routine: String::new(), functions: [None; 3] };
 
     let _unused = compress(&path, &mut movement);
@@ -96,13 +92,23 @@ pub fn part2(input: &Input) -> i64 {
         rules.push('\n');
     }
 
-    let mut modified = input.code.clone();
-    modified[0] = 2;
-
-    let mut computer = Computer::new(&modified);
     computer.input_ascii(&rules);
+    input.score = visit(computer);
 
-    visit(computer)
+    input
+}
+
+pub fn part1(input: &Input) -> i32 {
+    input
+        .scaffold
+        .iter()
+        .filter(|&point| ORTHOGONAL.iter().all(|&delta| input.scaffold.contains(&(*point + delta))))
+        .map(|point| point.x * point.y)
+        .sum()
+}
+
+pub fn part2(input: &Input) -> i64 {
+    input.score
 }
 
 /// Use a simple heuristic to build a path that visits every part of the scaffold at least once.

--- a/src/year2019/intcode.rs
+++ b/src/year2019/intcode.rs
@@ -3,7 +3,8 @@ use std::collections::VecDeque;
 
 /// [SWAG](https://en.wikipedia.org/wiki/Scientific_wild-ass_guess)
 /// It's possible that some inputs will need more space than this.
-const EXTRA: usize = 3_000;
+/// At least one input for day 17 is known to produce a grid size of 85x61 in this region.
+const EXTRA: usize = 6_000;
 
 pub enum State {
     Input,


### PR DESCRIPTION
## Description

Patch #23 increased the size of EXTRA storage used by Intcode for day 17, which expands a run-length-encoded layout into an actual grid in the memory after the program. But in searching through the megathreads, I found at least one input that produced an 85x61 grid, requiring more than 5000 extra slots, and much larger than my own 51x39 grid.

The part 2 machine starts with output identical to part 1, and startup
is a rather time-consuming chunk of the overall Intcode program (the
program first decompresses run-length-encoded data into the grid that
will subsequently be used by the rest of the program, before its first
output).  Moving part 2 computation into parse lets the two parts
share the overhead of just one program startup.
    
On my laptop, this changes parse()+part2() from 0.7+1.4ms to now being
1.4ms in parse() and part2() being practically instant.

## Type of change

- [X] Performance improvement
- [X] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
