### PR TITLE
Use Chinese Remainder Theorem rather than sieving

### DIFF
--- a/src/year2020/day13.rs
+++ b/src/year2020/day13.rs
@@ -4,10 +4,14 @@
 //! The integers n₁, n₂, ... nₖ map to the bus ids which happen to be prime. This satisfies the
 //! requirement that the integers are [pairwise coprime](https://en.wikipedia.org/wiki/Coprime_integers#Coprimality_in_sets).
 //!
-//! For simplicity we use the "search by sieving" method. We start at zero with a step the size of
-//! the first integer. Then we search for each subsequent integer located at the correct offset of
-//! minutes and multiply the step by the new integer. This preserves the relative offset at each step
-//! in the next search.
+//! This is similar to [`Year 2016 Day 15`]. However, in that year, the primes were all small,
+//! so that the number of iterations to solve by sieving was less effort than performing
+//! modular multiplication. For today's puzzle, however, a couple of primes are three digits,
+//! such that the number of iterations for sieving outweighs the effort for performing modular
+//! multiplications, especially when we can use `u128` for intermediate products to avoid
+//! numeric overflow.
+//!
+//! [`Year 2016 Day 15`]: crate::year2016::day15
 use crate::util::parse::*;
 
 pub struct Input {
@@ -42,14 +46,53 @@ pub fn part2(input: &Input) -> usize {
     let (mut time, mut step) = input.buses[0];
 
     for (offset, id) in &input.buses[1..] {
-        let remainder = id - offset % id;
+        // Scale id by enough to ensure a positive goal, then solve for x using the Chinese
+        // Remainder Theorem.
+        //     x ≡ a₁ (mod n₁) ≡ time (mod step)
+        //     x ≡ a₂ (mod n₂) ≡ goal (mod id)
+        //     N = n₁n₂ = product
+        let goal = (1000 * id - *offset) % id;
+        let product = id * step;
 
-        while time % id != remainder {
-            time += step;
-        }
+        // Use extended Euclidean division to obtain the respective modular inverses.
+        //     z₁ = n₂⁻¹ mod n₁
+        //     z₂ = n₁⁻¹ mod n₂
+        let (z1, z2) = extended_euclid(step, *id);
 
-        step *= id;
+        // Combine the two constituent parts. For this problem, time, step, z1, and z2 can reach
+        // around 50 bits, while id and goal are less than 10.
+        //     x ≡ a₁n₂z₁ + a₂n₁z₂ (mod n₁n₂)
+        let rem1 = modular_multiply(time, z2 * *id, product);
+        let rem2 = modular_multiply(goal * z1, step, product);
+        (time, step) = ((rem1 + rem2) % product, product);
     }
 
     time
+}
+
+// Given two coprime numbers, return their corresponding positive modular inverses using
+// extended Euclidean division to determine Bézout coefficients.
+fn extended_euclid(a: usize, b: usize) -> (usize, usize) {
+    let mut r1 = a as i64;
+    let mut r2 = b as i64;
+    let (mut m, mut s) = (1, 0);
+    let (mut n, mut t) = (0, 1);
+    while r2 != 0 {
+        let q = r1 / r2;
+        (r1, r2) = (r2, r1 - q * r2);
+        (m, s) = (s, m - q * s);
+        (n, t) = (t, n - q * t);
+    }
+    if m < 0 {
+        m += (a * b) as i64;
+    }
+    if n < 0 {
+        n += (a * b) as i64;
+    }
+    (m as usize, n as usize)
+}
+
+fn modular_multiply(a: usize, b: usize, modulus: usize) -> usize {
+    let product = (a as u128) * (b as u128);
+    (product % (modulus as u128)) as usize
 }


### PR DESCRIPTION
## Description

Sieving takes, on average, O(sum(factors)) iterations. Back in 2016 day 15, where there are only 7 primes all less than 100 (and their LCM still fits in 32 bits), this is fast. But for 2020 day 13, there are 9 primes with two over 400 (with LCM around 50 bits).  That means sieving will take around 1000 divisions.  Better is to just use CRT directly, implementing extended Euclidean division to compute coefficients, and modular multiplication to utilize u128 intermediates to avoid overflows, at which point the answer can be obtained with fewer hardware divisions.

On my laptop, this speeds up part2 runtime from 3.6us to 0.4us.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
