### PR TITLE
Compute result byte-by-byte without splitting string

### DIFF
--- a/src/year2020/day06.rs
+++ b/src/year2020/day06.rs
@@ -10,22 +10,58 @@
 //! [bitwise OR](https://en.wikipedia.org/wiki/Bitwise_operation) then count the number of ones
 //! for each group using the blazing fast [`count_ones`] intrinsic.
 //!
-//! Part two is very similar, except that we use a bitwise AND instead.
+//! Part two is very similar, except that we use a bitwise AND instead. It is faster to run
+//! both parts at once during the parse.
 //!
 //! [`day 5`]: crate::year2020::day05
 //! [`count_ones`]: u32::count_ones
-pub fn parse(input: &str) -> Vec<u32> {
-    input.lines().map(|line| line.bytes().fold(0, |acc, b| acc | (1 << (b - b'a')))).collect()
+use std::iter::once;
+
+type Input = (u32, u32);
+
+pub fn parse(input: &str) -> Input {
+    let mut any = 0_u32;
+    let mut all = u32::MAX;
+    let mut passenger = 0;
+    let mut part_one = 0;
+    let mut part_two = 0;
+    let iter = input.bytes();
+    let mut check_group = false;
+
+    // End the input with a double newline, to include last group in the total.
+    for ch in iter.chain(once(b'\n')) {
+        match ch {
+            b'\n' if check_group => {
+                // A second newline ends one group and prepares for the next.
+                check_group = false;
+                part_one += any.count_ones();
+                part_two += all.count_ones();
+                any = 0;
+                all = u32::MAX;
+            }
+            b'\n' => {
+                // A single newline separates passengers within a group.
+                any |= passenger;
+                all &= passenger;
+                passenger = 0;
+                check_group = true;
+            }
+            _ => {
+                // A letter sets the next bit for the given passenger.
+                // Masking to bits 1-26 is more efficient than subtracting to bits 0-25.
+                check_group = false;
+                passenger |= 1 << (ch & 31);
+            }
+        }
+    }
+
+    (part_one, part_two)
 }
 
-pub fn part1(input: &[u32]) -> u32 {
-    count_answers(input, u32::MIN, |group, passenger| group | passenger)
+pub fn part1(input: &Input) -> u32 {
+    input.0
 }
 
-pub fn part2(input: &[u32]) -> u32 {
-    count_answers(input, u32::MAX, |group, passenger| group & passenger)
-}
-
-fn count_answers(input: &[u32], initial: u32, combine: fn(u32, &u32) -> u32) -> u32 {
-    input.split(|&p| p == 0).map(|group| group.iter().fold(initial, combine).count_ones()).sum()
+pub fn part2(input: &Input) -> u32 {
+    input.1
 }

--- a/tests/year2020/day06.rs
+++ b/tests/year2020/day06.rs
@@ -15,7 +15,8 @@ a
 a
 a
 
-b";
+b
+";
 
 #[test]
 fn part1_test() {


### PR DESCRIPTION
## Description

This puzzle is very amenable to processing one byte at a time, with our own state machine. This is lower overhead than letting split find the boundary between passengers only to then revisit the bytes of the passenger ourselves.

On my laptop, this cuts runtime from 73us (parse at 63us, part1 and part2 at 5 use each) to just 20us (all in parse).

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
