### PR TITLE
Handle newlines more efficiently than input.lines()

### DIFF
--- a/src/year2020/day18.rs
+++ b/src/year2020/day18.rs
@@ -11,14 +11,75 @@
 //! * 1 + 2 * 3 + 4 => 1 + 2 * (3 + 4)
 //! * 1 + (2 * 3 * 4) + 5 => 1 + (2 * (3 * (4))) + 5
 use crate::util::parse::*;
-use std::str::Bytes;
+use std::slice::Iter;
 
-pub fn parse(input: &str) -> Vec<&str> {
-    input.lines().collect()
+/// A custom iterator treats each line of input as a parenthesized expression to add, so that
+/// the solver operates over the entire buffer without breaking it into lines.
+struct FlatIter<'a> {
+    bytes: Iter<'a, u8>,
+    state: State,
 }
 
-pub fn part1(input: &[&str]) -> u64 {
-    fn helper(bytes: &mut Bytes<'_>) -> u64 {
+#[derive(Clone, Copy)]
+enum State {
+    Start, // Need opening '(' for start of line.
+    Body,  // Emitting normal bytes from within a line.
+    End,   // Just supplied closing ')' at end of line.
+    Plus,  // Emitting '+' between lines.
+}
+
+impl<'a> FlatIter<'a> {
+    fn new(input: &'a [u8]) -> Self {
+        Self { bytes: input.iter(), state: State::Start }
+    }
+}
+
+impl Iterator for FlatIter<'_> {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.state {
+            State::Start => {
+                if self.bytes.len() == 0 {
+                    return None;
+                }
+                self.state = State::Body;
+                Some(b'(')
+            }
+            State::Body => {
+                match self.bytes.next() {
+                    // The expressions are consistently formatted so encountering a space just means
+                    // skip and return the next character that will always be present.
+                    Some(&b' ') => self.bytes.next().copied(),
+                    Some(&b'\n') | None => {
+                        self.state = State::End;
+                        Some(b')')
+                    }
+                    other => other.copied(),
+                }
+            }
+            State::End => {
+                if self.bytes.len() == 0 {
+                    None
+                } else {
+                    self.state = State::Plus;
+                    Some(b'+')
+                }
+            }
+            State::Plus => {
+                self.state = State::Body;
+                Some(b'(')
+            }
+        }
+    }
+}
+
+pub fn parse(input: &str) -> &str {
+    input
+}
+
+pub fn part1(input: &str) -> u64 {
+    fn helper(bytes: &mut FlatIter<'_>) -> u64 {
         let mut total = value(bytes, helper);
 
         while let Some(operation) = next(bytes) {
@@ -33,11 +94,12 @@ pub fn part1(input: &[&str]) -> u64 {
         total
     }
 
-    input.iter().map(|line| helper(&mut line.bytes())).sum()
+    let mut flat_iter = FlatIter::new(input.as_bytes());
+    helper(&mut flat_iter)
 }
 
-pub fn part2(input: &[&str]) -> u64 {
-    fn helper(bytes: &mut Bytes<'_>) -> u64 {
+pub fn part2(input: &str) -> u64 {
+    fn helper(bytes: &mut FlatIter<'_>) -> u64 {
         let mut total = value(bytes, helper);
 
         while let Some(operation) = next(bytes) {
@@ -54,23 +116,22 @@ pub fn part2(input: &[&str]) -> u64 {
         total
     }
 
-    input.iter().map(|line| helper(&mut line.bytes())).sum()
+    let mut flat_iter = FlatIter::new(input.as_bytes());
+    helper(&mut flat_iter)
 }
 
-/// Convenience wrapper around [`Bytes`] iterator. Encountering a `)` is also considered end of
-/// sequence. The expressions are consistently formatted so encountering a space just means
-/// skip and return the next character that will always be present.
-fn next(bytes: &mut Bytes<'_>) -> Option<u8> {
+/// Convenience wrapper around [`FlatIter`] iterator. Encountering a `)` is also considered end of
+/// sequence.
+fn next(bytes: &mut FlatIter<'_>) -> Option<u8> {
     match bytes.next() {
         None | Some(b')') => None,
-        Some(b' ') => bytes.next(),
         other => other,
     }
 }
 
 /// Convenience wrapper to return the value of either the next raw digit literal or a
 /// sub-expression nested in parentheses.
-fn value(bytes: &mut Bytes<'_>, helper: fn(&mut Bytes<'_>) -> u64) -> u64 {
+fn value(bytes: &mut FlatIter<'_>, helper: fn(&mut FlatIter<'_>) -> u64) -> u64 {
     match next(bytes).unwrap() {
         b'(' => helper(bytes),
         b => b.to_decimal() as u64,

--- a/tests/year2020/day18.rs
+++ b/tests/year2020/day18.rs
@@ -6,16 +6,17 @@ const EXAMPLE: &str = "\
 2 * 3 + (4 * 5)
 5 + (8 * 3 + 9 + 3 * 4 * 3)
 5 * 9 * (7 * 3 * 3 + 9 * 3 + (8 + 6 * 4))
-((2 + 4 * 9) * (6 + 9 * 8 + 6) + 6) + 2 + 4 * 2";
+((2 + 4 * 9) * (6 + 9 * 8 + 6) + 6) + 2 + 4 * 2
+";
 
 #[test]
 fn part1_test() {
     let input = parse(EXAMPLE);
-    assert_eq!(part1(&input), 26457);
+    assert_eq!(part1(input), 26457);
 }
 
 #[test]
 fn part2_test() {
     let input = parse(EXAMPLE);
-    assert_eq!(part2(&input), 694173);
+    assert_eq!(part2(input), 694173);
 }


### PR DESCRIPTION
## Description

By tracking our own stacks instead of using a recursion call stack, it is possible to solve part 1 and 2 in parallel as part of the parse. Provides a slight speedup; on my machine, I measured 82us pre-patch, and 72us with the patch included.  The testsuite needs a trailing newline to match expectations.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
