### PR TITLE
Short-circuit the search by exploiting the sorted array

### DIFF
--- a/src/year2020/day01.rs
+++ b/src/year2020/day01.rs
@@ -8,50 +8,49 @@
 //! For part one we use an implicit hash table in an array, since values are constrained to between
 //! 0 and 2020 and each value is already perfectly hashed. For each entry we check the index
 //! at its value. If this is marked then we have seen the reciprocal `2020 - value` before
-//! so we can return the product. If not then we mark the reciprocal value in the array.
+//! so we have found the answer. Creating this array also performs a radix sort that will
+//! be used in part two.
 //!
-//! Part two reuses the pair finding logic, finding the third element by stepping through the slice
-//! one by one and adjusting the target total. To reuse the array without reallocating
-//! (which is slow) we use a `round` value instead of `bool`.
+//! Part two adds a second array, this time containing the product of any two numbers that
+//! sum to that point. Since the problem only has one correct answer, it does not matter if
+//! other array slots get written more than once. Because the list is already sorted, we can short
+//! circuit iterations as soon as a sum is not possible.
 use crate::util::parse::*;
 
-pub fn parse(input: &str) -> Vec<usize> {
-    let mut numbers: Vec<usize> = input.iter_unsigned().collect();
-    // Assume that, after sorting, the solutions are closer to the middle of the vector than the
-    // extremes. It's not necessary for correctness but improves the average running time for
-    // most (all?) inputs.
-    numbers.sort_unstable();
-    numbers
+type Input = (usize, [bool; 2020]);
+
+pub fn parse(input: &str) -> Input {
+    let mut numbers = [false; 2020];
+    let mut part_one = 0;
+
+    // Part one is determined as a side effect of the parse. Assume the input has no duplicates.
+    for number in input.iter_unsigned::<usize>() {
+        if numbers[2020 - number] {
+            part_one = number * (2020 - number);
+        }
+        numbers[number] = true;
+    }
+
+    // The parse performed a radix sort; numbers can now be used as an ordered sparse array.
+    (part_one, numbers)
 }
 
-pub fn part1(input: &[usize]) -> usize {
-    let mut hash = [0; 2020];
-    two_sum(input, 2020, &mut hash, 1).unwrap()
+pub fn part1(input: &Input) -> usize {
+    input.0
 }
 
-pub fn part2(input: &[usize]) -> usize {
-    let mut hash = [0; 2020];
+pub fn part2(input: &Input) -> usize {
+    let (_, numbers) = input;
 
-    (0..input.len() - 2)
-        .find_map(|i| {
-            let first = input[i];
-            let round = i + 1;
-            let target = 2020 - first;
-            two_sum(&input[round..], target, &mut hash, round).map(|product| first * product)
-        })
-        .unwrap()
-}
-
-fn two_sum(slice: &[usize], target: usize, hash: &mut [usize], round: usize) -> Option<usize> {
-    for &i in slice {
-        if i < target {
-            let complement = target - i;
-            if hash[i] == round {
-                return Some(i * complement);
+    // We know at least one of the three numbers is at least 2020/3.
+    for i in 674..2020 {
+        for j in 1..i {
+            let k = 2020 - i - j;
+            if numbers[i] && numbers[j] && numbers[k] {
+                return i * j * k;
             }
-            hash[complement] = round;
         }
     }
 
-    None
+    unreachable!()
 }


### PR DESCRIPTION
## Description

A recent patch sorted the array of numbers on the grounds that the average runtime improves when visiting pairs in ascending order.  But we can go one further: the mere act of creating our hash for the part one answer is a radix sort.  Even though walking O(buckets) after an O(n) radix sort (2020 buckets if we iterate them all) is slightly slower than an O(n log n) item sort (with n=200, this is about 200*8=1600 comparisons), we can additionally take advantage of the fact that things are sorted by exploiting the triangle inequality: at least one of the items will be at least 2020/3, and another will be less than the integer we are using as our pivot point.  With a simple enough loop, the compiler can see the loop invariants and hoist 0 checks earlier; and even though the loop is still quadratic, input files have fewer low entries so this completes even faster.  With this, parse() speeds up because it is no longer doing a duplicate O(n log n) sort, part1() speeds up because it is now done as a side effect of parse, and part2() is slightly faster.
    
On my laptop, this changes parse/part1/part2 runtime from 2.0/0.3/0.4 (2.7us total) to 0.8/0.0/0.2 (1.0us total), less than half the time.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [x] Pull request title and commit messages are clear and informative.
- [x] Documentation has been updated if necessary.
- [x] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [x] Tests pass `cargo test`
- [x] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [x] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
