### PR TITLE
Compute median with less effort

### DIFF
--- a/src/year2021/day07.rs
+++ b/src/year2021/day07.rs
@@ -29,10 +29,13 @@ pub fn part2(input: &[i32]) -> i32 {
 
 fn median(input: &[i32]) -> i32 {
     let mut crabs = input.to_vec();
-    crabs.sort_unstable();
+    let mid = crabs.len() / 2;
+    assert!(crabs.len().is_multiple_of(2));
 
-    let half = input.len() / 2;
-    if crabs.len().is_multiple_of(2) { crabs[half - 1].midpoint(crabs[half]) } else { crabs[half] }
+    crabs.select_nth_unstable(mid);
+    let upper = crabs[mid];
+    let lower = crabs[..mid].iter().max().unwrap();
+    (lower + upper) / 2
 }
 
 fn mean(input: &[i32]) -> i32 {


### PR DESCRIPTION
## Description

Instead of performing an O(n log n) sort_unstable, we can use the O(n) select_nth_unstable to get at the median element. Since the input size is always even (1000 crabs in the actual input, 10 in the example), we need the average between two elements - but it is also O(n) to grab the neighbor once we have the array segregated by the median element.

On my laptop, this cuts part1() from 6.6us to 2.4us (overall day drops from 11us to 7us).

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
