### PR TITLE
Another median where quickselect is faster

### DIFF
--- a/src/year2021/day03.rs
+++ b/src/year2021/day03.rs
@@ -64,13 +64,9 @@ pub fn part2(input: &Input) -> usize {
 
     // Perform a binary search over the tree.
     for _ in 0..*size {
-        ogr = 2 * ogr + if tree[ogr + 1] >= tree[ogr] { 2 } else { 0 };
-        csr =
-            2 * csr + if tree[csr + 1].wrapping_sub(1) < tree[csr].wrapping_sub(1) { 2 } else { 0 };
+        ogr = 2 * (ogr + usize::from(tree[ogr + 1] >= tree[ogr]));
+        csr = 2 * (csr + usize::from(tree[csr + 1].wrapping_sub(1) < tree[csr].wrapping_sub(1)));
     }
 
-    ogr = ogr / 2 - offset;
-    csr = csr / 2 - offset;
-
-    ogr * csr
+    (ogr / 2 - offset) * (csr / 2 - offset)
 }

--- a/src/year2021/day10.rs
+++ b/src/year2021/day10.rs
@@ -27,8 +27,9 @@ pub fn parse(input: &str) -> Input {
         stack.clear();
     }
 
-    scores.sort_unstable();
-    let part_two = scores[scores.len() / 2];
+    let idx = scores.len() / 2;
+    scores.select_nth_unstable(idx);
+    let part_two = scores[idx];
 
     (part_one, part_two)
 }


### PR DESCRIPTION
## Description

O(n) select_nth_unstable is faster than O(n log n) sort_unstable.

On my laptop, this speeds up from 42us to 36us.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
