### PR TITLE
Pre-compute impact factors at compile time

### DIFF
--- a/src/year2021/day06.rs
+++ b/src/year2021/day06.rs
@@ -6,26 +6,50 @@
 //! Another optimization trick is rather than modifying the array by removing the fish at day 0,
 //! then shifting each fish total down by 1, we can simply increment what we consider the
 //! head of the array modulo 9 to achieve the same effect in place.
-use crate::util::parse::*;
+//!
+//! What's more, the computation of how many fish result after N generations for a single starting fish
+//! can be determined up front.  With a table containing only `9*257` u64 entries (about 18k
+//! memory) computed at compile time, we can determine the two answers in constant runtime.
 
 type Input = [u64; 9];
 
+const DAYS: usize = 256;
+const TIMERS: usize = 9;
+static IMPACT: [[u64; TIMERS]; DAYS + 1] = {
+    let mut table = [[0; TIMERS]; DAYS + 1];
+
+    let mut timer = 0;
+    while timer < TIMERS {
+        table[0][timer] = 1;
+        timer += 1;
+    }
+
+    let mut day = 0;
+    while day < DAYS {
+        let mut timer = 0;
+        while timer < TIMERS {
+            table[day + 1][(timer + 1) % TIMERS] = table[day][timer];
+            timer += 1;
+        }
+        table[day + 1][0] += table[day][6];
+        day += 1;
+    }
+
+    table
+};
+
 pub fn parse(input: &str) -> Input {
     let mut fish = [0_u64; 9];
-    input.iter_unsigned().for_each(|i: usize| fish[i] += 1);
+    for ch in input.as_bytes().iter().step_by(2) {
+        fish[(ch & 0xf) as usize] += 1;
+    }
     fish
 }
 
 pub fn part1(input: &Input) -> u64 {
-    simulate(input, 80)
+    input.iter().zip(&IMPACT[80]).map(|(fish, impact)| fish * impact).sum()
 }
 
 pub fn part2(input: &Input) -> u64 {
-    simulate(input, 256)
-}
-
-fn simulate(input: &Input, days: usize) -> u64 {
-    let mut fish = *input;
-    (0..days).for_each(|day| fish[(day + 7) % 9] += fish[day % 9]);
-    fish.iter().sum()
+    input.iter().zip(&IMPACT[256]).map(|(fish, impact)| fish * impact).sum()
 }


### PR DESCRIPTION
## Description

This puzzle is already blindingly fast. But we can make it faster with an 18k table of compile-time constants, by pre-computing a single fish's impact over N generations, so that the runtime only has to compute the dot product of the initial numbers of fish with the constants for the target day.

On my laptop, this cuts the runtime from 750ns to 310ns.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
