### PR TITLE
Yet another faster computation of median

### DIFF
--- a/src/year2021/day07.rs
+++ b/src/year2021/day07.rs
@@ -1,11 +1,14 @@
 //! # The Treachery of Whales
 //!
 //! Part one is a disguised definition of the mathematical [median](https://en.wikipedia.org/wiki/Median).
-//! We can calculate the result immediately using the standard algorithm.
+//! We can calculate the result immediately using the standard algorithm. Even though there
+//! are an even number of crabs, any integer between the 500th and 501st crab inclusive will
+//! work (the extra fuel spent by half the crabs perfectly cancels the fuel saved by the other
+//! half, when switching between integers in that range).
 //!
 //! Part two is found by using the [mean](https://en.wikipedia.org/wiki/Mean).
 //! However, since this could be a floating point value and we are using integers we need to check
-//! 3 values total, the rounded result and one value on either side to ensure the correct answer.
+//! both the floor and the ceiling of that result to ensure the correct answer.
 use crate::util::parse::*;
 
 pub fn parse(input: &str) -> Vec<i32> {
@@ -24,18 +27,15 @@ pub fn part2(input: &[i32]) -> i32 {
         (n * (n + 1)) / 2
     };
 
-    (-1..=1).map(|delta| input.iter().map(|&x| triangle(x, mean + delta)).sum()).min().unwrap()
+    (0..=1).map(|delta| input.iter().map(|&x| triangle(x, mean + delta)).sum()).min().unwrap()
 }
 
 fn median(input: &[i32]) -> i32 {
+    // A radix sort followed by a short-circuiting .position() would also work, but takes
+    // more lines of code without much more speed.
     let mut crabs = input.to_vec();
-    let mid = crabs.len() / 2;
-    assert!(crabs.len().is_multiple_of(2));
-
-    crabs.select_nth_unstable(mid);
-    let upper = crabs[mid];
-    let lower = crabs[..mid].iter().max().unwrap();
-    (lower + upper) / 2
+    let middle = crabs.len() / 2;
+    *crabs.select_nth_unstable(middle).1
 }
 
 fn mean(input: &[i32]) -> i32 {


### PR DESCRIPTION
## Description

I experimented with a radix sort instead of quickselect. Since the input file has more crabs below 1000 than above (proof: exactly 500 3-digit and 500 4-digit crabs would be a file size of 4500, but input files are closer to 3900 bytes), a radix sort can find the median in under 2000 operations (1000 writes to a 2048-entry hash table, then < 1000 buckets crawled).  But it takes more code, so sticking with quickselect (whose best case is 2*n operations if the pivots are chosen well, so just over 2000 operations) is more maintainable with the difference in effort in the noise.  But more importantly, even though we have an even number of crabs (and thus two choices on either side of the true median), we know that any integer between those two boundaries (if the two crabs are not at the same position) will produce the same fuel score, so there is no need to compute the TRUE median; less work makes for a faster part 1.

And for part 2, we can prove that the correct answer will come from either truncating or rounding the mean to the nearest integer; it is not necessary to search one below the truncated value.

On my laptop, this reduces part1() from 2.3us to 2.0us; and part2() from 1.4us to 1.0us.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
