### PR TITLE
Add an A* search that outperforms Dijkstra

### DIFF
--- a/src/year2021/day15.rs
+++ b/src/year2021/day15.rs
@@ -1,18 +1,42 @@
 //! # Chiton
 //!
 //! Traversing a graph with different non-negative edge weights is a job for the classic
-//! [Dijkstra's algorithm](https://www.redblobgames.com/pathfinding/a-star/introduction.html),
+//! [A* algorithm](https://www.redblobgames.com/pathfinding/a-star/introduction.html),
 //! explained really well in the linked blog post.
 //!
-//! To speed things up we use a trick. Classic Dijkstra uses a generic priority queue that
-//! can be implemented in Rust using a [`BinaryHeap`]. However, the total cost follows a strictly
-//! increasing order in a constrained range of values, so we can use a much faster single purpose
-//! data structure instead.
+//! The simplest possible heuristic in A* is to make no estimate at all, making the search
+//! behave the same as Dijkstra's algorithm. With that heuristic, the search frontier visits
+//! nearly every tile, since only a few tiles near the target might have a total risk higher
+//! than the target itself. Slightly better is a heuristic of the Manhattan distance to the
+//! target; although this still underestimates and prunes no more than 5% of the total search
+//! space. Logically this makes sense: Manhattan distance only changes by 1 per tile, but with risks
+//! between 1-9, the average risk is closer to 5, and our best path averages closer to 3 risk per
+//! tile. But we can do much better with a heuristic that prunes about 75% of the search space,
+//! by assigning a value within 2% of the actual cost for each node. In the long run, it is
+//! faster to visit all 250,000 to set up a fairly close estimate which lets us prune the search
+//! space to under 60,000 nodes, than it is to skip the heuristic but have a search space near
+//! 250,000 nodes, since the effort of searching is less predictable than the effort to compute
+//! the heuristic.
 //!
-//! The maximum possible increase in risk is 9, so we create an array of 10 `vec`s. The current
-//! list of items to process is at `risk % 10` and each new item is added at `risk % 10 + new_cost`.
-//! Once we have processed the current risk level we clear the vec to avoid having to reallocate
-//! memory.
+//! The heuristic we use builds up an estimate for the minimum cost incurred from each node to
+//! the destination. The target itself starts with its risk level. Then for every diagonal line of
+//! tiles, starting next to the target and ending next to the origin, a given tile's estimate is
+//! chosen to be its own risk level plus the minimum of the tile below, the tile to the right,
+//! or the minimum Manhattan distance to reach any other tile on the same diagonal with a better
+//! estimate. Building this up requires traveling each diagonal twice (the first pass captures
+//! any better tiles below and left, the second pass captures any tiles above and right). Allowing
+//! other tiles on the same diagonal to influence the current tile's estimate covers the case where
+//! the optimal path moves up or left around an obstacle. Failure to consider the ability to
+//! reach other tiles on the same diagonal via an unseen path that loops around a wall would result
+//! in a heuristic that is not admissible in A*. At the same time, without actually verifying
+//! whether same-diagonal tiles can actually be reached in the estimated Manhattan distance, the
+//! heuristic is no longer perfectly consistent, which means in practice we can sometimes see a
+//! neighbor point inserted into the work queue with a priority one less than the current tile.
+//!
+//! With our heuristic, the maximum possible increase in risk is 9, compounded with the maximum
+//! jump in the estimate table of another 9. A circular array of 32 buckets (for bitwise math
+//! windowing) can handle our empirical range of -1 to 18 in the set of active buckets, and we
+//! avoid having to allocate memory as the search gradually shifts the active window of buckets.
 //!
 //! [`BinaryHeap`]: std::collections::BinaryHeap
 use crate::util::parse::*;
@@ -32,7 +56,7 @@ pub fn parse(input: &str) -> Square {
 
 /// Search the regular size grid.
 pub fn part1(input: &Square) -> usize {
-    dijkstra(input)
+    astar(input, build_estimates(input))
 }
 
 /// Create an expanded grid then search.
@@ -54,39 +78,108 @@ pub fn part2(input: &Square) -> usize {
         }
     }
 
-    dijkstra(&expanded)
+    astar(&expanded, build_estimates(&expanded))
 }
 
-/// Implementation of [Dijkstra's algorithm](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm)
-/// without using the decrease-key functionality.
-fn dijkstra(square: &Square) -> usize {
+// Create a table of heuristics for use in an A* search. This is admissible (never overestimates)
+// but not consistent (the diagonal clamping can sometimes change a node's estimated score by more
+// than its risk, necessitating the search queue to jump back a bucket).
+fn build_estimates(square: &Square) -> Vec<u32> {
     let Square { size, bytes } = square;
     let edge = size - 1;
     let end = size * size - 1;
 
-    // Initialize our specialized priority queue with 10 vecs.
-    let mut todo: [Vec<u32>; 10] = from_fn(|_| Vec::with_capacity(1_000));
-    let mut cost = vec![u16::MAX; size * size];
-    let mut risk = 0;
+    let mut estimate = vec![0_u32; size * size];
+    // Produce a coordinate in estimate, or 0 if x or y out of bounds. Since the origin does
+    // not contribute to the overall risk level, we use it instead to hold an effective infinity
+    // to make processing easier at the ends of diagonals.
+    let coord = |col: usize, row: usize| -> usize {
+        if col > edge || row > edge { 0 } else { row * size + col }
+    };
+    estimate[0] = u32::MAX; // Larger than any possible other estimate.
+
+    // Give the target its own risk level.
+    estimate[end] = bytes[end] as u32;
+
+    // Visit the grid by diagonals, starting closest to the target.
+    for diag in (1..edge * 2).rev() {
+        let mut best_diag = u32::MAX - 18;
+        let range: Vec<usize> = (diag.saturating_sub(edge)..edge.min(diag) + 1).collect();
+
+        // For each tile crawling up and right, select the minimum between its lower neighbor,
+        // its right neighbor, or the minimum Manhattan distance to any earlier node on the diagonal.
+        for &col in &range {
+            let row = diag - col;
+            let value =
+                estimate[coord(col + 1, row)].min(estimate[coord(col, row + 1)]).min(best_diag + 2)
+                    + bytes[coord(col, row)] as u32;
+            estimate[coord(col, row)] = value;
+            best_diag = if best_diag + 2 < value { best_diag + 2 } else { value };
+        }
+
+        // For each tile crawling down and left, also check for the minimum Manhattan distance from
+        // any better node earlier on the diagonal.
+        best_diag = u32::MAX - 18;
+        for &col in range.iter().rev() {
+            let row = diag - col;
+            let value =
+                estimate[coord(col, row)].min(best_diag + 2 + bytes[coord(col, row)] as u32);
+            estimate[coord(col, row)] = value;
+            best_diag = if best_diag + 2 < value { best_diag + 2 } else { value };
+        }
+    }
+
+    // The final estimate for the origin is about 2% shy of the actual risk level.
+    estimate[0] = estimate[1].min(estimate[*size]);
+    estimate
+}
+
+/// Implementation of [A* algorithm](https://en.wikipedia.org/wiki/A*_search_algorithm)
+/// without using the decrease-key functionality.
+fn astar(square: &Square, mut grid_data: Vec<u32>) -> usize {
+    let Square { size, bytes } = square;
+    let edge = size - 1;
+    let end = size * size - 1;
+
+    // Initialize our specialized priority queue with 32 vecs. Chosen to be large enough
+    // to cover the largest gap (actual risk increasing by 9 on the same step that the
+    // heuristic jumps by 9), but also safe against the infrequent backwards jump by 1.
+    let mut todo: [Vec<u32>; 32] = from_fn(|_| Vec::with_capacity(1_000));
+
+    // On entry, grid_data contains estimates in the low 16 bits. As long as all estimates
+    // are transformed uniformly by a constant, the sequence of nodes visited will be identical.
+    // For best memory use, we prefer operating with the estimates in the high 16 bits,
+    // and the cost to reach a node in the low 16 bits, with the initial cost estimate of
+    // u16::MAX as a sentinel that the node has not been visited yet.
+    for cell in &mut grid_data {
+        *cell = (*cell << 16) - 1;
+    }
 
     // Start location and risk are both zero.
-    todo[0].push(0);
-    cost[0] = 0;
+    let mut i = (grid_data[0] >> 16) as usize;
+    todo[i & 31].push(0);
+    grid_data[0] = 0;
 
     loop {
-        let i = risk % 10;
+        while todo[i & 31].is_empty() {
+            i += 1;
+        }
 
-        for j in 0..todo[i].len() {
-            let current = todo[i][j] as usize;
+        if let Some(current) = todo[i & 31].pop() {
+            let current = current as usize;
+            let risk = (grid_data[current] & 0xffff) as usize;
             if current == end {
                 return risk;
             }
 
             let mut check = |next: usize| {
-                let next_cost = risk as u16 + bytes[next] as u16;
-                if next_cost < cost[next] {
-                    todo[(next_cost % 10) as usize].push(next as u32);
-                    cost[next] = next_cost;
+                let next_cost = risk + bytes[next] as usize;
+                if next_cost < grid_data[next] as usize & 0xffff {
+                    let next_f = risk + (grid_data[next] >> 16) as usize;
+                    // Cope if this resulted in the rare backward jump.
+                    i = i.min(next_f);
+                    todo[next_f & 31].push(next as u32);
+                    grid_data[next] = (grid_data[next] & !0xffff) | next_cost as u32;
                 }
             };
             let x = current % size;
@@ -105,8 +198,5 @@ fn dijkstra(square: &Square) -> usize {
                 check(current + size);
             }
         }
-
-        todo[i].clear();
-        risk += 1;
     }
 }


### PR DESCRIPTION
## Description

For this search problem (optimal path across diagonal endpoints of a square grid of integers 1-9), a naive A* search using Manhattan distance to the goal underestimates. That's because the average tile is 5, but Manhattan distance only accounts for 1; and we end up spending more time on the heuristic than we gain in path pruning (in instrumented code, Dijkstra visits all 250000 nodes of my part 2, while the naive A* is able to prune about 20 of those nodes).  In the other direction, a heuristic built up only from cells to the right or below the current cell overestimates (if the heuristic does not account for the possibility of the lowest-risk path sometimes needing to go up or left through a valley of 1s to skirt around a wall of 9s, then A* will accidentally prune that path despite it being the best).

However, the megathread had an observation on a way to build a deterministic heuristic that never overestimates, while still approaching within 2% of the actual cost - for every diagonal of the grid, reduce a given node's heuristic if it can reach another cheaper node on the same diagonal via an unseen Manhattan path assumed to be all 1s.  Without actually having to visit nodes off the diagonal to see if the assumption is valid, this will sometimes underestimate (so we DO need the A* search as a followup pass, rather than being able to solve the puzzle just by computing heuristics), but never overestimate.  The resulting heuristic is admissible but not consistent; on my input, I had several instances where the estimate reduction applied by looking along the same diagonal resulted in revisiting an earlier bucket that had already been emptied; however, the range of buckets populated is still fairly tight (never more than -1 to 18 away from the current bucket), and the bucket window gradually shifts as the underestimate grows closer to reality the closer we get to the target (for my puzzle, the estimate at the origin was low by only 64 out of nearly 3000).  With the heuristic in place, the A* search drops down to about 55k nodes searched (ie. pruning away over 75% of the grid). The time spent visiting all 250000 nodes to populate the heuristic (with its regular memory accesses that can be vectorized) is less than the time saved by not searching the bulk of the grid (where the search frontier tends to be more random-access and thus slower per iteration), making this a net win over Dijkstra.

On my laptop and input, runtime improves from 155us for part1() and 4.4ms for part2(), to instead being 70us and 3.0ms.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
