### PR TITLE
Speed up basin collection

### DIFF
--- a/src/year2021/day09.rs
+++ b/src/year2021/day09.rs
@@ -7,68 +7,69 @@
 //! such as a [`VecDeque`].
 //!
 //! This solution uses a DFS approach as it's faster and Rust's stack size limit seems enough
-//! to accommodate the maximum basin size. 2-dimensional grids are common in Advent of Code
-//! problems so we use our utility [`Grid`] and [`Point`] modules.
+//! to accommodate the maximum basin size. While we could use the [`Grid`] and [`Point`] modules
+//! to take in the original grid one line at a time with 2D coordinates, it turns out to be
+//! somewhat faster to instead just operate on a 1D array with an explicit border, where newline
+//! is treated the same as `'9'`, in order to eliminate bounds checking. We can also tweak the
+//! flood fill to track the lowest value seen along the way, to share the work between part
+//! one and part two.
 //!
 //! [`VecDeque`]: std::collections::VecDeque
 //! [`Grid`]: crate::util::grid
 //! [`Point`]: crate::util::point
-use crate::util::grid::*;
-use crate::util::parse::*;
-use crate::util::point::*;
 
-pub fn parse(input: &str) -> Grid<u8> {
-    Grid::parse(input)
+pub struct Basin {
+    lowest: u32, // Lowest integer seen within basin so far.
+    size: u32,   // Number of cells in the basin.
 }
 
-pub fn part1(grid: &Grid<u8>) -> u32 {
-    let mut risk_levels = 0;
+pub fn parse(input: &str) -> Vec<Basin> {
+    // Create a larger grid with all borders already filled with 9.
+    let width = input.lines().next().unwrap().len() + 1;
+    let mut grid = Vec::with_capacity(input.len() + 2 * width);
+    grid.resize(width, b'9');
+    grid.extend_from_slice(input.as_bytes());
+    grid.resize(grid.len() + width, b'9');
 
-    for y in 0..grid.height {
-        for x in 0..grid.width {
-            let point = Point::new(x, y);
-            let cur = grid[point];
-            let low_point = ORTHOGONAL
-                .into_iter()
-                .map(|n| point + n)
-                .filter(|&n| grid.contains(n))
-                .all(|n| grid[n] > cur);
-
-            if low_point {
-                risk_levels += 1 + cur.to_decimal() as u32;
-            }
+    // Collect all basins in the grid. Masking with 15 turns '0' through '9' into their numeric
+    // value, and '\n' into 10, so that we can use newline as a second barrier character.
+    let mut basins = Vec::with_capacity(256);
+    for idx in width..width + input.len() {
+        if grid[idx] & 15 < 9 {
+            basins.push(flood_fill(&mut grid, idx, width as isize));
         }
     }
 
-    risk_levels
+    // Note that select_nth_unstable will partition the array faster than a full sort; with the
+    // partition in place, the final three elements are the largest.
+    let pivot = basins.len() - 3;
+    basins.select_nth_unstable_by_key(pivot, |b| b.size);
+
+    basins
 }
 
-pub fn part2(input: &Grid<u8>) -> u32 {
-    let mut grid = input.clone();
-    let mut basins = Vec::new();
-
-    for y in 0..grid.height {
-        for x in 0..grid.width {
-            let next = Point::new(x, y);
-            if grid[next] < b'9' {
-                basins.push(flood_fill(&mut grid, next));
-            }
-        }
-    }
-
-    basins.sort_unstable();
-    basins.iter().rev().take(3).product()
+pub fn part1(basins: &[Basin]) -> u32 {
+    basins.iter().map(|b| b.lowest + 1).sum::<u32>()
 }
 
-fn flood_fill(grid: &mut Grid<u8>, point: Point) -> u32 {
-    grid[point] = b'9';
+pub fn part2(basins: &[Basin]) -> u32 {
+    // The list of basins is not sorted overall, but does have the largest three at the end.
+    basins[basins.len() - 3..].iter().map(|b| b.size).product()
+}
+
+fn flood_fill(grid: &mut [u8], idx: usize, width: isize) -> Basin {
+    let mut lowest = (grid[idx] & 15) as u32;
     let mut size = 1;
+    grid[idx] = b'9';
 
-    for next in ORTHOGONAL.map(|d| point + d) {
-        if grid.contains(next) && grid[next] < b'9' {
-            size += flood_fill(grid, next);
+    for delta in [1, -1, width, -width] {
+        let other = idx.wrapping_add(delta as usize);
+        if grid[other] & 15 < 9 {
+            let basin = flood_fill(grid, other, width);
+            lowest = lowest.min(basin.lowest);
+            size += basin.size;
         }
     }
 
-    size
+    Basin { lowest, size }
 }


### PR DESCRIPTION
## Description

By being a bit smarter about basin collection, our flood fill can gather both the lowest point and size simultaneously; this means moving the basin collection into parse(), and leaving part1() and part2() to be the final post-processing of the collected basins. Supplying an explicit border lets the flood fill perform fewer conditionals (every neighbor point probed is in bounds).  Using a full O(n log n) sort is slow compared to using select_nth_unstable to partition the three largest elements to the end in O(n) effort.

On my laptop, this speeds up the problem from 3/45/127 (around 170us total) to instead being 86us all in parse.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
