### PR TITLE
Speed up part 1, and demonstrate a compile-time solution to part 2

### DIFF
--- a/src/year2021/day21.rs
+++ b/src/year2021/day21.rs
@@ -20,10 +20,27 @@ pub fn parse(input: &str) -> State {
 /// The initial deterministic dice roll total is 6 (1 + 2 + 3) and increases by 9 each turn.
 /// An interesting observation is that since the player's position is always modulo 10, we can
 /// also increase the dice total modulo 10, as (a + b) % 10 = (a % 10) + (b % 10).
+/// Additionally, both players end up in the same position every 10 moves, so we can pre-compute
+/// the score per 10 moves before simulating the remainder.
 pub fn part1(input: &State) -> usize {
     let mut state = *input;
     let mut dice = 6;
-    let mut rolls = 0;
+    let ((player_position, _), (other_position, _)) = state;
+
+    // Player 1 loops through offsets 6, 10, 2, 2, 10, 6, 10, 2, 2, 10.
+    let skip_one = 4 * ((player_position + 2) % 10 + 1)
+        + 2 * ((player_position + 6) % 10 + 1)
+        + 4 * (player_position + 1);
+    // Player 2 cycles through offsets 5, 8, 9, 8, 5, 10, 3, 4, 3, 10.
+    let skip_two = 2 * ((other_position + 3) % 10 + 1)
+        + ((other_position + 4) % 10 + 1)
+        + 2 * ((other_position + 5) % 10 + 1)
+        + 2 * ((other_position + 8) % 10 + 1)
+        + ((other_position + 9) % 10 + 1)
+        + 2 * (other_position + 1);
+    let skips = 999 / skip_one.max(skip_two);
+    let mut rolls = skips * 60;
+    state = ((player_position, skip_one * skips), (other_position, skip_two * skips));
 
     loop {
         // Player position is 0 based from 0 to 9, but score is 1 based from 1 to 10.
@@ -51,39 +68,97 @@ pub fn part1(input: &State) -> usize {
 /// Each player can be in position 1 to 10 and can have a score from 0 to 20 (as a score of 21
 /// ends the game). This is a total of (10 × 21)² = 44,100 possible states. For speed this
 /// can fit in an array with perfect hashing, instead of using a slower `HashMap`.
+///
+/// In fact, the cache can be computed and utilized only at compile time; there are only 100 possible
+/// starting locations.
 pub fn part2(input: &State) -> usize {
-    let mut cache = vec![None; 44_100];
-    let (win, lose) = dirac(*input, &mut cache);
-    win.max(lose)
+    let ((player_position, _), (other_position, _)) = *input;
+    ANSWER_TABLE[player_position][other_position]
 }
 
-fn dirac(state: State, cache: &mut [Option<Pair>]) -> Pair {
-    let ((player_position, player_score), (other_position, other_score)) = state;
+const fn flat_index(
+    player_position: usize,
+    other_position: usize,
+    player_score: usize,
+    other_score: usize,
+) -> usize {
+    player_position + 10 * other_position + 100 * player_score + 2100 * other_score
+}
 
-    // Calculate the perfect hash of the state and lookup the cache in case we've seen this before.
-    let index = player_position + 10 * other_position + 100 * player_score + 2100 * other_score;
-    if let Some(result) = cache[index] {
-        return result;
+const fn compute_cache() -> [(usize, usize); 44_100] {
+    let mut cache = [(0, 0); 44_100];
+
+    // Iterate in reverse by total score, so that dependencies are available.
+    let mut total_score = 40;
+    loop {
+        let mut player_score = 0;
+        while player_score < 21 {
+            if total_score >= player_score && (total_score - player_score) < 21 {
+                let other_score = total_score - player_score;
+
+                let mut player_position = 0;
+                while player_position < 10 {
+                    let mut other_position = 0;
+                    while other_position < 10 {
+                        let mut player_wins = 0;
+                        let mut other_wins = 0;
+
+                        let mut i = 0;
+                        while i < DIRAC.len() {
+                            let (dice, frequency) = DIRAC[i];
+                            let next_position = (player_position + dice) % 10;
+                            let next_score = player_score + next_position + 1;
+
+                            if next_score >= 21 {
+                                player_wins += frequency;
+                            } else {
+                                let idx = flat_index(
+                                    other_position,
+                                    next_position,
+                                    other_score,
+                                    next_score,
+                                );
+                                let (next_other_wins, next_player_wins) = cache[idx];
+                                player_wins += next_player_wins * frequency;
+                                other_wins += next_other_wins * frequency;
+                            }
+                            i += 1;
+                        }
+
+                        let idx =
+                            flat_index(player_position, other_position, player_score, other_score);
+                        cache[idx] = (player_wins, other_wins);
+
+                        other_position += 1;
+                    }
+                    player_position += 1;
+                }
+            }
+            player_score += 1;
+        }
+        if total_score == 0 {
+            break;
+        }
+        total_score -= 1;
     }
 
-    let helper = |(win, lose), &(dice, frequency)| {
-        let next_position = (player_position + dice) % 10;
-        let next_score = player_score + next_position + 1;
-
-        if next_score >= 21 {
-            (win + frequency, lose)
-        } else {
-            // Sneaky trick here to handle both players with the same function.
-            // We swap the order of player's state each turn, so that turns alternate
-            // and record the result as (lose, win) instead of (win, lose).
-            let next_state = ((other_position, other_score), (next_position, next_score));
-            let (next_lose, next_win) = dirac(next_state, cache);
-            (win + frequency * next_win, lose + frequency * next_lose)
-        }
-    };
-
-    // Compute the number of wins and losses from this position and add to the cache.
-    let result = DIRAC.iter().fold((0, 0), helper);
-    cache[index] = Some(result);
-    result
+    cache
 }
+
+const ANSWER_TABLE: [[usize; 10]; 10] = {
+    let cache = compute_cache();
+    let mut table = [[0; 10]; 10];
+
+    let mut player_position = 0;
+    while player_position < 10 {
+        let mut other_position = 0;
+        while other_position < 10 {
+            let (wins, losses) = cache[flat_index(player_position, other_position, 0, 0)];
+            table[player_position][other_position] = if wins > losses { wins } else { losses };
+            other_position += 1;
+        }
+        player_position += 1;
+    }
+
+    table
+};


### PR DESCRIPTION
## Description

The dynamic solution only fills up about 30% of the 44100 cache entries; but it is not much harder to turn the cache into a deterministic dynamic-programming table filled up to 100% at compile time, at which point the runtime for part 2 drops to a mere nanosecond for a table lookup covering all possible inputs (quite a bit faster than the 800us it took beforehand).  Part 1 can also be speed up by recognizing that the visitation pattern is periodic, and thus we can skip forward a period at a time (dropping from 1300 to 100 ns on my machine).  However, since compile time is drastically increased (over 10 seconds on my machine), and since part 1 runtime is in the noise compared to part 2, I suspect that this patch is more of a cool demo, and not something to actually be applied.

## Type of change

- [X] Performance improvement (demo)
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
