### PR TITLE
Skip positive arc on probe trajectory

### DIFF
--- a/src/year2021/day17.rs
+++ b/src/year2021/day17.rs
@@ -122,6 +122,11 @@ pub fn part2(input: &Input) -> usize {
     for mut dy in min_dy..max_dy {
         let mut y = 0;
         let mut t = 0;
+        // Skip the positive arc, assuming top is negative.
+        if dy > 0 {
+            t = 2 * dy as usize + 1;
+            dy = -dy - 1;
+        }
         let mut first = true;
 
         while y >= bottom {


### PR DESCRIPTION
## Description

Using the same reasoning as in part 1, if we fire off a probe with dy initially positive, we know it will eventually reach back to the same level as the sub with the same speed in the opposite direction. And since the top of the target range is below the sub, none of the time spent flying through that arc affects total, so we can skip past it.

On my laptop, this speeds up runtime from 5.1us to 2.3us.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
