### PR TITLE
Add new Grid::parse_with_border method

### DIFF
--- a/src/util/grid.rs
+++ b/src/util/grid.rs
@@ -16,13 +16,18 @@
 //! assert_eq!(grid[point], b'2');
 //! ```
 //!
-//! A convenience [`parse`] method creates a `Grid` directly from a 2-dimensional set of
-//! ASCII characters, a common occurrence in Advent of Code inputs. The [`same_size_with`] function
-//! creates a grid of the same size that can be used in BFS algorithms for tracking visited
-//! locations or for tracking cost in Dijkstra.
+//! Two convenience methods, [`parse`] and [`parse_with_border`], create a `Grid` directly from a
+//! 2-dimensional set of ASCII characters, a common occurrence in Advent of Code inputs. The former
+//! strips all newlines, and [`contains`] is then useful to prevent accidental wraparound between
+//! lines. The latter not only preserves newlines in the input, but adds a row of newlines above and
+//! below, for algorithms where newline serves as a natural barrier without needing to use
+//! [`contains`]. The [`same_size_with`] function creates a grid of the same size that can be used
+//! in BFS algorithms for tracking visited locations or for tracking cost in Dijkstra.
 //!
 //! [`Point`]: crate::util::point
 //! [`parse`]: Grid::parse
+//! [`parse_with_border`]: Grid::parse_with_border
+//! [`contains`]: Grid::contains
 //! [`same_size_with`]: Grid::same_size_with
 use std::ops::{Index, IndexMut};
 
@@ -45,6 +50,25 @@ impl Grid<u8> {
         let bytes = raw.concat();
 
         Self { width, height, bytes }
+    }
+
+    #[must_use]
+    pub fn parse_with_border(input: &str) -> Self {
+        // Size things large enough so that both orthogonal and diagonal access hits a newline.
+        // This shifts 0,0 to 1,1. Non-newline iteration would be `1..height-1` and `1..width`,
+        // although it still often faster to iterate `0..height` and `0..width` when visiting
+        // newline is harmless. For convenience, the allocation is oversized to compensate for unit
+        // tests that omit a trailing newline.
+        let width = input.lines().next().unwrap().len() + 1;
+        let height = input.len().div_ceil(width) + 2;
+        let size = width * height + 1;
+        let mut bytes = Vec::with_capacity(size);
+
+        bytes.resize(width + 1, b'\n');
+        bytes.extend_from_slice(input.as_bytes());
+        bytes.resize(size, b'\n');
+
+        Self { width: width as i32, height: height as i32, bytes }
     }
 
     pub fn print(&self) {

--- a/src/year2020/day11.rs
+++ b/src/year2020/day11.rs
@@ -15,7 +15,8 @@ use crate::util::point::*;
 const SEAT: u8 = b'L';
 
 pub fn parse(input: &str) -> Grid<u8> {
-    Grid::parse(input)
+    // A newline border allows us to avoid boundary checks.
+    Grid::parse_with_border(input)
 }
 
 pub fn part1(input: &Grid<u8>) -> u32 {
@@ -29,6 +30,8 @@ pub fn part2(input: &Grid<u8>) -> u32 {
 #[cfg(not(feature = "simd"))]
 mod implementation {
     use super::*;
+
+    const FLOOR: u8 = b'.';
 
     struct Seat {
         point: Point,
@@ -54,11 +57,11 @@ mod implementation {
 
                     // Part one considers only the adjacent square. Part two skips over any
                     // floor until reaching the first visible seat or the edge of the grid.
-                    while part_two && input.contains(next) && input[next] != SEAT {
+                    while part_two && input[next] == FLOOR {
                         next += direction;
                     }
 
-                    if input.contains(next) && input[next] == SEAT {
+                    if input[next] == SEAT {
                         neighbors[size] = next;
                         size += 1;
                     }
@@ -101,17 +104,17 @@ mod implementation {
 
     pub(super) fn simulate(input: &Grid<u8>, part_two: bool, limit: u8) -> u32 {
         // Input grid is taller than it is wide. To make efficient use of the wide SIMD operations:
-        // * Add an empty border to eliminate bounds checking.
+        // * Change the existing newline border to empty, but keep it to eliminate bounds checking.
         // * Transpose the input grid to make it wider than it is tall.
         // * Round width up to next multiple of LANE_WIDTH.
-        let width = 2 + (input.height as usize).next_multiple_of(LANE_WIDTH) as i32;
-        let height = 2 + input.width;
+        let width = 2 + (input.height as usize - 2).next_multiple_of(LANE_WIDTH) as i32;
+        let height = 1 + input.width;
         let mut grid = Grid::new(width, height, 0);
 
         for y in 0..input.height {
             for x in 0..input.width {
                 let from = Point::new(x, y);
-                let to = Point::new(y + 1, x + 1);
+                let to = Point::new(y, x);
                 grid[to] = u8::from(input[from] == SEAT);
             }
         }

--- a/src/year2021/day09.rs
+++ b/src/year2021/day09.rs
@@ -7,16 +7,16 @@
 //! such as a [`VecDeque`].
 //!
 //! This solution uses a DFS approach as it's faster and Rust's stack size limit seems enough
-//! to accommodate the maximum basin size. While we could use the [`Grid`] and [`Point`] modules
-//! to take in the original grid one line at a time with 2D coordinates, it turns out to be
-//! somewhat faster to instead just operate on a 1D array with an explicit border, where newline
-//! is treated the same as `'9'`, in order to eliminate bounds checking. We can also tweak the
-//! flood fill to track the lowest value seen along the way, to share the work between part
-//! one and part two.
+//! to accommodate the maximum basin size. Note that when masked, newline can be treated
+//! the same as `'9'` for a natural barrier that eliminates bounds checking. The [`Grid`] and
+//! [`Point`] modules make it easy to perform a flood fill that tracks the lowest value seen along
+//! the way, to share the work between part one and part two.
 //!
 //! [`VecDeque`]: std::collections::VecDeque
 //! [`Grid`]: crate::util::grid
 //! [`Point`]: crate::util::point
+use crate::util::grid::*;
+use crate::util::point::*;
 
 pub struct Basin {
     lowest: u32, // Lowest integer seen within basin so far.
@@ -24,19 +24,18 @@ pub struct Basin {
 }
 
 pub fn parse(input: &str) -> Vec<Basin> {
-    // Create a larger grid with all borders already filled with 9.
-    let width = input.lines().next().unwrap().len() + 1;
-    let mut grid = Vec::with_capacity(input.len() + 2 * width);
-    grid.resize(width, b'9');
-    grid.extend_from_slice(input.as_bytes());
-    grid.resize(grid.len() + width, b'9');
+    // A newline border allows us to avoid boundary checks.
+    let mut grid = Grid::parse_with_border(input);
 
     // Collect all basins in the grid. Masking with 15 turns '0' through '9' into their numeric
     // value, and '\n' into 10, so that we can use newline as a second barrier character.
     let mut basins = Vec::with_capacity(256);
-    for idx in width..width + input.len() {
-        if grid[idx] & 0xf < 9 {
-            basins.push(flood_fill(&mut grid, idx, width as isize));
+    for y in 0..grid.height {
+        for x in 0..grid.width {
+            let point = Point::new(x, y);
+            if grid[point] & 0xf < 9 {
+                basins.push(flood_fill(&mut grid, point));
+            }
         }
     }
 
@@ -57,15 +56,14 @@ pub fn part2(basins: &[Basin]) -> u32 {
     basins[basins.len() - 3..].iter().map(|b| b.size).product()
 }
 
-fn flood_fill(grid: &mut [u8], idx: usize, width: isize) -> Basin {
-    let mut lowest = (grid[idx] & 0xf) as u32;
+fn flood_fill(grid: &mut Grid<u8>, point: Point) -> Basin {
+    let mut lowest = (grid[point] & 0xf) as u32;
     let mut size = 1;
-    grid[idx] = b'9';
+    grid[point] = b'9';
 
-    for delta in [1, -1, width, -width] {
-        let other = idx.wrapping_add_signed(delta);
-        if grid[other] & 0xf < 9 {
-            let basin = flood_fill(grid, other, width);
+    for next in ORTHOGONAL.map(|d| point + d) {
+        if grid[next] & 0xf < 9 {
+            let basin = flood_fill(grid, next);
             lowest = lowest.min(basin.lowest);
             size += basin.size;
         }

--- a/src/year2022/day12.rs
+++ b/src/year2022/day12.rs
@@ -28,7 +28,8 @@ type Input = (u32, u32);
 ///
 /// [`Grid`]: crate::util::grid
 pub fn parse(input: &str) -> Input {
-    let mut grid = Grid::parse(input);
+    // A newline border allows us to avoid boundary checks.
+    let mut grid = Grid::parse_with_border(input);
 
     // Run the BFS algorithm implementation with the reversed height transition rules baked in.
     // In fact, we don't need a separate seen grid; we can modify the original grid in place.
@@ -39,17 +40,15 @@ pub fn parse(input: &str) -> Input {
 
     while let Some((point, height, cost)) = todo.pop_front() {
         for next in ORTHOGONAL.map(|d| d + point) {
-            if grid.contains(next) {
-                if grid[next] == b'S' {
-                    return (cost, part_two.unwrap());
+            if grid[next] == b'S' {
+                return (cost, part_two.unwrap());
+            }
+            if grid[next] >= height {
+                if grid[next] == b'a' {
+                    part_two = part_two.or(Some(cost));
                 }
-                if grid[next] >= height {
-                    if grid[next] == b'a' {
-                        part_two = part_two.or(Some(cost));
-                    }
-                    todo.push_back((next, grid[next] - 1, cost + 1));
-                    grid[next] = 0;
-                }
+                todo.push_back((next, grid[next] - 1, cost + 1));
+                grid[next] = 0;
             }
         }
     }

--- a/src/year2023/day16.rs
+++ b/src/year2023/day16.rs
@@ -40,14 +40,14 @@ impl Node {
     }
 }
 
-/// Fixed size bitset large enough to store the entire 110 x 110 grid.
+/// Fixed size bitset large enough to store the entire 110 x 110 grid plus border.
 struct BitSet {
-    bits: [u64; 190],
+    bits: [u64; 196],
 }
 
 impl BitSet {
     fn new() -> Self {
-        Self { bits: [0; 190] }
+        Self { bits: [0; 196] }
     }
 
     fn insert(&mut self, position: Point) {
@@ -76,7 +76,8 @@ enum State {
 
 /// Computes both parts together in order to reuse cached results.
 pub fn parse(input: &str) -> Input {
-    let grid = Grid::parse(input);
+    // A newline border allows us to avoid boundary checks.
+    let grid = Grid::parse_with_border(input);
     let width = grid.width;
     let height = grid.height;
 
@@ -88,16 +89,17 @@ pub fn parse(input: &str) -> Input {
         nodes: Vec::new(),
     };
 
-    let part_one = follow(graph, ORIGIN, RIGHT);
+    let part_one = follow(graph, Point::new(1, 1), RIGHT);
     let mut part_two = part_one;
 
-    for x in 0..width {
-        part_two = part_two.max(follow(graph, Point::new(x, 0), DOWN));
-        part_two = part_two.max(follow(graph, Point::new(x, height - 1), UP));
+    // The newline border is asymmetric: the right border is implicit thanks to wraparound.
+    for x in 1..width {
+        part_two = part_two.max(follow(graph, Point::new(x, 1), DOWN));
+        part_two = part_two.max(follow(graph, Point::new(x, height - 2), UP));
     }
 
-    for y in 0..height {
-        part_two = part_two.max(follow(graph, Point::new(0, y), RIGHT));
+    for y in 1..height - 1 {
+        part_two = part_two.max(follow(graph, Point::new(1, y), RIGHT));
         part_two = part_two.max(follow(graph, Point::new(width - 1, y), LEFT));
     }
 
@@ -120,8 +122,10 @@ pub fn part2(input: &Input) -> u32 {
 fn follow(graph: &mut Graph, mut position: Point, mut direction: Point) -> u32 {
     let mut node = Node::new();
 
-    while graph.grid.contains(position) {
+    loop {
         match graph.grid[position] {
+            // A newline border ends the path.
+            b'\n' => break,
             // Retrieve cached value or compute recursively.
             b'|' | b'-' => {
                 let index = match graph.state[position] {
@@ -154,8 +158,10 @@ fn follow(graph: &mut Graph, mut position: Point, mut direction: Point) -> u32 {
 
 /// Traces the path of a beam until we hit the flat side of another splitter or exit the grid.
 fn beam(graph: &mut Graph, node: &mut Node, mut position: Point, mut direction: Point) {
-    while graph.grid.contains(position) {
+    loop {
         match graph.grid[position] {
+            // A newline border ends the path.
+            b'\n' => break,
             b'|' => {
                 // If we encounter the pointy edge of a splitter then this additional splitter is
                 // also part of this node. Nodes can contain multiple splitters in the same path.

--- a/src/year2023/day21.rs
+++ b/src/year2023/day21.rs
@@ -90,14 +90,15 @@ use std::collections::VecDeque;
 use crate::util::grid::*;
 use crate::util::point::*;
 
-const CENTER: Point = Point::new(65, 65);
+const CENTER: Point = Point::new(66, 66);
 const CORNERS: [Point; 4] =
-    [Point::new(0, 0), Point::new(130, 0), Point::new(0, 130), Point::new(130, 130)];
+    [Point::new(1, 1), Point::new(131, 1), Point::new(1, 131), Point::new(131, 131)];
 
 type Input = (u64, u64);
 
 pub fn parse(input: &str) -> Input {
-    let grid = Grid::parse(input);
+    // A newline border allows us to avoid boundary checks.
+    let grid = Grid::parse_with_border(input);
 
     // Search from the center tile outwards.
     let (even_inner, even_outer, odd_inner, odd_outer) = bfs(&grid, &[CENTER], 130);
@@ -160,7 +161,7 @@ fn bfs(grid: &Grid<u8>, starts: &[Point], limit: u32) -> (u64, u64, u64, u64) {
 
         if cost < limit {
             for next in ORTHOGONAL.map(|o| position + o) {
-                if grid.contains(next) && grid[next] != b'#' {
+                if grid[next] == b'.' {
                     grid[next] = b'#';
                     todo.push_back((next, cost + 1));
                 }


### PR DESCRIPTION
## Description

Several puzzles perform motion along a grid where the motion can be naturally bounded by an explicit newline character. In those cases, discarding the newline in the input and making the code do a .contains() check is more overhead than creating an oversized grid where the input's newlines serve as left AND right boundary (thanks to 1D wraparound), and where we can supply additional newlines on top and bottom at parse time.

While there are probably other puzzles that would also benefit, I picked the following to demonstrate the utility of the new parse_with_border() method, with timings on my laptop and inputs:

 - 2020 day 11
   - Non-SIMD timing improves from part1() 5.3ms and part2() 4.1ms to now complete in 4.3ms and 4.0ms
   - SIMD code was already supplying its own border, but timings with the updated transpose stay at part1() 200us and part2 1.4ms.
 - 2021 day 9 Timing remains around parse() 80us; updating #98 to use the new interface does not hurt the timing.
 - 2022 day 12 Timing improves from part1+part2 56+51us to 51+46us.
 - 2023 day 16 Timing improves from parse() 330us to 325us.
 - 2023 day 21 Timing improves from 310us to 260us.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
