### PR TITLE
Less memory churn in search for candidate lines

### DIFF
--- a/src/year2022/day15.rs
+++ b/src/year2022/day15.rs
@@ -86,10 +86,11 @@ pub fn part2(input: &[Input]) -> u64 {
 /// Of the entire 4000000 by 4000000 area the missing beacon must be located in the only
 /// square area not covered by a scanner.
 pub fn part2_testable(input: &[Input], size: i32) -> u64 {
-    let mut top = FastSet::new();
-    let mut left = FastSet::new();
-    let mut bottom = FastSet::new();
-    let mut right = FastSet::new();
+    let capacity = input.len();
+    let mut top = FastSet::with_capacity(capacity);
+    let mut left = FastSet::with_capacity(capacity);
+    let mut bottom = FastSet::with_capacity(capacity);
+    let mut right = FastSet::with_capacity(capacity);
 
     // Rotate points clockwise by 45 degrees, scale by √2 and extend edge by 1.
     // This transforms each sensor into an axis aligned bounding box.
@@ -106,6 +107,8 @@ pub fn part2_testable(input: &[Input], size: i32) -> u64 {
     let vertical: Vec<_> = left.intersection(&right).copied().collect();
     let range = 0..=size;
 
+    // Many input files have vertical.len() == 1 and horizontal.len() == 1, which implies exactly
+    // one answer; but this check covers more situations and is not too expensive.
     for &x in &vertical {
         for &y in &horizontal {
             // Rotate intersection point counter-clockwise and scale by 1 / √2

--- a/src/year2022/day15.rs
+++ b/src/year2022/day15.rs
@@ -108,7 +108,7 @@ pub fn part2_testable(input: &[Input], size: i32) -> u64 {
     let range = 0..=size;
 
     // Many input files have vertical.len() == 1 and horizontal.len() == 1, which implies exactly
-    // one answer; but this check covers more situations and is not too expensive.
+    // one answer, but this check covers more situations and is not too expensive.
     for &x in &vertical {
         for &y in &horizontal {
             // Rotate intersection point counter-clockwise and scale by 1 / √2


### PR DESCRIPTION
## Description

Pre-allocating the FastSets rather than growing them as edges are encountered drastically reduces the runtime.  The sets are almost small enough that an in-memory O(n^2) sort of 1600 comparisons for a 40-line input might still beat the O(n) set intersection with the overhead of hashing.

On my laptop, this cuts runtime from 3.4us to 1.4us.

## Type of change

- [X] Performance improvement
- [ ] Bug fix
- [ ] Other

## Checklist

- [X] Pull request title and commit messages are clear and informative.
- [X] Documentation has been updated if necessary.
- [X] Code style matches the existing code. This one is somewhat subjective, but try to "fit in" by
  using the same naming conventions. Code should be portable, avoiding any
  architecture-specific intrinsics.
- [X] Tests pass `cargo test`
- [X] Code is formatted ``cargo fmt -- `find . -name "*.rs"` ``
- [X] Code is linted `cargo clippy --all-targets --all-features`

Formatting and linting also can be executed by running [`just`](https://github.com/casey/just)
(if installed) on the command line at the project root.
